### PR TITLE
Добавить передачу живой телеметрии в ABRP

### DIFF
--- a/app/src/main/kotlin/com/bydmate/app/data/remote/IternioTelemetryClient.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/remote/IternioTelemetryClient.kt
@@ -1,0 +1,123 @@
+package com.bydmate.app.data.remote
+
+import android.location.Location
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Отправляет живые показатели автомобиля в Iternio Telemetry API (A Better Route Planner).
+ *
+ * Документация: https://documenter.getpostman.com/view/7396339/SWTK5a8w
+ * Формат тела: application/x-www-form-urlencoded:
+ * - token: пользовательский токен живых данных из ABRP
+ * - tlm: JSON-объект с телеметрией в метрических единицах
+ */
+@Singleton
+class IternioTelemetryClient @Inject constructor(
+    private val httpClient: OkHttpClient
+) {
+    companion object {
+        private const val TAG = "IternioTelemetry"
+        private const val SEND_URL = "https://api.iternio.com/1/tlm/send"
+    }
+
+    /**
+     * @param apiKey API-ключ Iternio для приложения.
+     * @param userToken Токен живых данных автомобиля из ABRP.
+     */
+    suspend fun send(
+        apiKey: String,
+        userToken: String,
+        data: DiParsData,
+        location: Location?,
+        carModel: String?,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        val token = userToken.trim()
+        if (token.isEmpty()) return@withContext Result.failure(IllegalArgumentException("пустой токен"))
+
+        try {
+            val telemetry = JSONObject()
+            telemetry.put("utc", System.currentTimeMillis() / 1000)
+
+            data.soc?.let { telemetry.put("soc", it) }
+            data.speed?.let { telemetry.put("speed", it) }
+            data.power?.let { p -> telemetry.put("power", p) }
+
+            data.avgBatTemp?.let { telemetry.put("batt_temp", it) }
+            data.exteriorTemp?.let { telemetry.put("ext_temp", it) }
+            data.batteryCapacityKwh?.let { telemetry.put("capacity", it) }
+            data.mileage?.let { telemetry.put("odometer", it) }
+            data.insideTemp?.let { telemetry.put("cabin_temp", it) }
+            data.tirePressFL?.let { telemetry.put("tire_pressure_fl", it) }
+            data.tirePressFR?.let { telemetry.put("tire_pressure_fr", it) }
+            data.tirePressRL?.let { telemetry.put("tire_pressure_rl", it) }
+            data.tirePressRR?.let { telemetry.put("tire_pressure_rr", it) }
+
+            telemetry.put("is_charging", if (isCharging(data)) 1 else 0)
+            data.gear?.let { telemetry.put("is_parked", if (it == 1) 1 else 0) }
+
+            location?.let { loc ->
+                telemetry.put("lat", loc.latitude)
+                telemetry.put("lon", loc.longitude)
+                if (loc.hasAltitude()) {
+                    telemetry.put("elevation", loc.altitude)
+                }
+            }
+
+            carModel?.trim()?.takeIf { it.isNotEmpty() }?.let { telemetry.put("car_model", it) }
+
+            val form = FormBody.Builder()
+                .add("token", token)
+                .add("tlm", telemetry.toString())
+
+            val url = SEND_URL.toHttpUrl().newBuilder().apply {
+                val key = apiKey.trim()
+                if (key.isNotEmpty()) addQueryParameter("api_key", key)
+            }.build()
+
+            val request = Request.Builder()
+                .url(url)
+                .post(form.build())
+                .build()
+
+            httpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "HTTP ${response.code}: $body")
+                    return@withContext Result.failure(
+                        IllegalStateException("HTTP ${response.code}")
+                    )
+                }
+                try {
+                    val status = JSONObject(body).optString("status")
+                    if (status.isNotBlank() && !status.equals("ok", ignoreCase = true)) {
+                        Log.w(TAG, "API error: $body")
+                        return@withContext Result.failure(IllegalStateException(body))
+                    }
+                } catch (_: Exception) { /* Пустой или не-JSON ответ считаем успешным при HTTP 2xx. */ }
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.w(TAG, "отправка не удалась: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+    private fun isCharging(data: DiParsData): Boolean {
+        if (data.chargeGunState == 2) return true
+        val p = data.power
+        if (p != null && p < 0) return true
+        // Значения chargingStatus отличаются между прошивками, поэтому активные коды трактуем мягко.
+        val cs = data.chargingStatus
+        if (cs != null && cs > 0) return true
+        return false
+    }
+}

--- a/app/src/main/kotlin/com/bydmate/app/data/repository/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/repository/SettingsRepository.kt
@@ -32,6 +32,17 @@ open class SettingsRepository @Inject constructor(
         const val KEY_ALICE_ENDPOINT = "alice_endpoint"
         const val KEY_ALICE_API_KEY = "alice_api_key"
         const val KEY_ALICE_ENABLED = "alice_enabled"
+        /** Передавать живые данные DiPars + GPS в A Better Route Planner (Iternio Telemetry API). */
+        const val KEY_ABRP_ENABLED = "abrp_telemetry_enabled"
+        /** API-ключ приложения Iternio ([abetterrouteplanner.com/resources/api](https://abetterrouteplanner.com/resources/api)). */
+        const val KEY_ABRP_API_KEY = "abrp_api_key"
+        /** Токен живых данных автомобиля из ABRP. */
+        const val KEY_ABRP_USER_TOKEN = "abrp_user_token"
+        /** Необязательный код модели автомобиля из библиотеки ABRP. */
+        const val KEY_ABRP_CAR_MODEL = "abrp_car_model"
+        /** Минимальный интервал между отправками телеметрии, секунды (5–120). */
+        const val KEY_ABRP_INTERVAL_SEC = "abrp_interval_sec"
+        const val DEFAULT_ABRP_INTERVAL_SEC = "12"
         const val KEY_DATA_SOURCE = "data_source"
         const val KEY_AUTOSERVICE_ENABLED = "autoservice_enabled"
         const val KEY_LAST_MILEAGE_KM = "last_mileage_km"

--- a/app/src/main/kotlin/com/bydmate/app/service/TrackingService.kt
+++ b/app/src/main/kotlin/com/bydmate/app/service/TrackingService.kt
@@ -23,6 +23,7 @@ import com.bydmate.app.data.automation.AutomationEngine
 import com.bydmate.app.data.remote.AlicePollingManager
 import com.bydmate.app.data.remote.DiParsClient
 import com.bydmate.app.data.remote.DiParsData
+import com.bydmate.app.data.remote.IternioTelemetryClient
 import com.bydmate.app.data.repository.ChargeRepository
 import com.bydmate.app.domain.tracker.TripState
 import com.bydmate.app.domain.tracker.TripTracker
@@ -68,6 +69,7 @@ class TrackingService : Service(), LocationListener {
     @Inject lateinit var socInterpolator: SocInterpolator
     @Inject lateinit var rangeCalculator: RangeCalculator
     @Inject lateinit var autoserviceDetector: com.bydmate.app.data.charging.AutoserviceChargingDetector
+    @Inject lateinit var iternioTelemetryClient: IternioTelemetryClient
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var pollingJob: Job? = null
@@ -106,6 +108,9 @@ class TrackingService : Service(), LocationListener {
     // kwh/hours heuristic for short sessions.
     @Volatile private var prevChargeGunState: Int? = null
     @Volatile private var observedChargingPowerKwAbs: Double = 0.0
+
+    private val iternioTelemetryLock = Any()
+    @Volatile private var lastIternioTelemetryMs: Long = 0L
 
     companion object {
         private const val TAG = "TrackingService"
@@ -355,6 +360,59 @@ class TrackingService : Service(), LocationListener {
             "samples=${liveTripBuffer.sampleCount()}")
     }
 
+    /**
+     * Отправка в [IternioTelemetryClient] с ограничением частоты, без блокировки цикла опроса.
+     */
+    private fun maybeSendIternioTelemetry(data: DiParsData, loc: Location?, nowMs: Long) {
+        serviceScope.launch {
+            try {
+                if (settingsRepository.getString(
+                        com.bydmate.app.data.repository.SettingsRepository.KEY_ABRP_ENABLED,
+                        "false"
+                    ) != "true"
+                ) {
+                    return@launch
+                }
+                val token = settingsRepository.getString(
+                    com.bydmate.app.data.repository.SettingsRepository.KEY_ABRP_USER_TOKEN,
+                    ""
+                ).trim()
+                if (token.isEmpty()) return@launch
+
+                val intervalSec = settingsRepository.getString(
+                    com.bydmate.app.data.repository.SettingsRepository.KEY_ABRP_INTERVAL_SEC,
+                    com.bydmate.app.data.repository.SettingsRepository.DEFAULT_ABRP_INTERVAL_SEC
+                ).toIntOrNull()?.coerceIn(5, 120) ?: 12
+                val intervalMs = intervalSec * 1000L
+                synchronized(iternioTelemetryLock) {
+                    if (nowMs - lastIternioTelemetryMs < intervalMs) return@launch
+                    lastIternioTelemetryMs = nowMs
+                }
+
+                val apiKey = settingsRepository.getString(
+                    com.bydmate.app.data.repository.SettingsRepository.KEY_ABRP_API_KEY,
+                    ""
+                )
+                val carModel = settingsRepository.getString(
+                    com.bydmate.app.data.repository.SettingsRepository.KEY_ABRP_CAR_MODEL,
+                    ""
+                ).trim().takeIf { it.isNotEmpty() }
+
+                iternioTelemetryClient.send(
+                    apiKey = apiKey,
+                    userToken = token,
+                    data = data,
+                    location = loc,
+                    carModel = carModel,
+                ).onFailure { e ->
+                    Log.w(TAG, "Телеметрия Iternio: ${e.message}")
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Телеметрия Iternio: ${e.message}")
+            }
+        }
+    }
+
     override fun onDestroy() {
         Log.i(TAG, "onDestroy: stopping TrackingService")
         com.bydmate.app.ui.widget.WidgetController.detach()
@@ -562,6 +620,7 @@ class TrackingService : Service(), LocationListener {
                         automationEngine.evaluate(data, sessionId)
                         updateNotification(data)
                         maybeLogSessionSummary(nowMs, data, sessionId)
+                        maybeSendIternioTelemetry(data, loc, nowMs)
                     } else {
                         consecutiveNullCount++
                         if (consecutiveNullCount >= NULL_WARNING_THRESHOLD) {

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
@@ -431,6 +431,97 @@ fun SettingsScreen(
                     }
                 }
 
+                SectionHeader(text = "ABRP — телеметрия")
+                Card(
+                    shape = RoundedCornerShape(12.dp),
+                    colors = CardDefaults.cardColors(containerColor = CardSurface),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    val context = LocalContext.current
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(modifier = Modifier.weight(1f).padding(end = 8.dp)) {
+                                Text(
+                                    "Живые данные → A Better Route Planner",
+                                    color = TextPrimary,
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Text(
+                                    "Показатели DiPlus и GPS отправляются в Iternio Telemetry API для актуального плана в ABRP.",
+                                    color = TextSecondary,
+                                    fontSize = 12.sp,
+                                )
+                            }
+                            Switch(
+                                checked = state.abrpTelemetryEnabled,
+                                onCheckedChange = { viewModel.toggleAbrpTelemetry(it) },
+                                colors = bydSwitchColors(),
+                            )
+                        }
+                        SettingsTextField(
+                            label = "API-ключ Iternio (опционально)",
+                            value = state.abrpApiKey,
+                            onValueChange = { viewModel.updateAbrpApiKey(it) },
+                            keyboardType = KeyboardType.Password
+                        )
+                        SettingsTextField(
+                            label = "Токен живых данных из ABRP",
+                            value = state.abrpUserToken,
+                            onValueChange = { viewModel.updateAbrpUserToken(it) },
+                            keyboardType = KeyboardType.Password
+                        )
+                        SettingsTextField(
+                            label = "Код модели ABRP (опционально)",
+                            value = state.abrpCarModel,
+                            onValueChange = { viewModel.updateAbrpCarModel(it) },
+                            keyboardType = KeyboardType.Text
+                        )
+                        SettingsTextField(
+                            label = "Интервал отправки, сек (5–120)",
+                            value = state.abrpIntervalSec,
+                            onValueChange = { viewModel.updateAbrpIntervalSec(it) },
+                            keyboardType = KeyboardType.Number
+                        )
+                        Button(
+                            onClick = { viewModel.saveAbrpSettings() },
+                            enabled = state.abrpUserToken.isNotBlank(),
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(8.dp),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = AccentGreen,
+                                contentColor = NavyDark
+                            )
+                        ) {
+                            Text("Сохранить ABRP", fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                        }
+                        state.abrpSaveStatus?.let {
+                            Text(it, color = AccentGreen, fontSize = 12.sp)
+                        }
+                        Text(
+                            "Документация API: Postman → телеметрия Iternio",
+                            color = AccentBlue,
+                            fontSize = 12.sp,
+                            textDecoration = TextDecoration.Underline,
+                            modifier = Modifier.clickable {
+                                context.startActivity(
+                                    Intent(
+                                        Intent.ACTION_VIEW,
+                                        Uri.parse("https://documenter.getpostman.com/view/7396339/SWTK5a8w")
+                                    )
+                                )
+                            }
+                        )
+                    }
+                }
+
                 // --- Плавающий виджет ---
                 val widgetCtx = LocalContext.current
                 val widgetPrefs = remember { WidgetPreferences(widgetCtx) }

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsViewModel.kt
@@ -115,7 +115,13 @@ data class SettingsUiState(
     val dataSource: String = "ENERGYDATA",
     val dataSourceStatus: String? = null,
     val autoserviceEnabled: Boolean = false,
-    val autoserviceStatus: AutoserviceStatus = AutoserviceStatus.NotEnabled
+    val autoserviceStatus: AutoserviceStatus = AutoserviceStatus.NotEnabled,
+    val abrpTelemetryEnabled: Boolean = false,
+    val abrpApiKey: String = "",
+    val abrpUserToken: String = "",
+    val abrpCarModel: String = "",
+    val abrpIntervalSec: String = SettingsRepository.DEFAULT_ABRP_INTERVAL_SEC,
+    val abrpSaveStatus: String? = null,
 )
 
 @HiltViewModel
@@ -195,6 +201,15 @@ class SettingsViewModel @Inject constructor(
 
             val autoserviceEnabled = settingsRepository.isAutoserviceEnabled()
 
+            val abrpEnabled = settingsRepository.getString(SettingsRepository.KEY_ABRP_ENABLED, "false") == "true"
+            val abrpApiKey = settingsRepository.getString(SettingsRepository.KEY_ABRP_API_KEY, "")
+            val abrpUserToken = settingsRepository.getString(SettingsRepository.KEY_ABRP_USER_TOKEN, "")
+            val abrpCarModel = settingsRepository.getString(SettingsRepository.KEY_ABRP_CAR_MODEL, "")
+            val abrpIntervalSec = settingsRepository.getString(
+                SettingsRepository.KEY_ABRP_INTERVAL_SEC,
+                SettingsRepository.DEFAULT_ABRP_INTERVAL_SEC
+            )
+
             _uiState.update {
                 it.copy(
                     batteryCapacity = capacity,
@@ -216,6 +231,11 @@ class SettingsViewModel @Inject constructor(
                     aliceEnabled = aliceEnabled,
                     dataSource = dataSource,
                     autoserviceEnabled = autoserviceEnabled,
+                    abrpTelemetryEnabled = abrpEnabled,
+                    abrpApiKey = abrpApiKey,
+                    abrpUserToken = abrpUserToken,
+                    abrpCarModel = abrpCarModel,
+                    abrpIntervalSec = abrpIntervalSec,
                 )
             }
 
@@ -641,6 +661,51 @@ class SettingsViewModel @Inject constructor(
         _uiState.update { it.copy(aliceEnabled = enabled) }
         viewModelScope.launch {
             settingsRepository.setString(SettingsRepository.KEY_ALICE_ENABLED, enabled.toString())
+        }
+    }
+
+    fun toggleAbrpTelemetry(enabled: Boolean) {
+        _uiState.update { it.copy(abrpTelemetryEnabled = enabled) }
+        viewModelScope.launch {
+            settingsRepository.setString(SettingsRepository.KEY_ABRP_ENABLED, enabled.toString())
+        }
+    }
+
+    fun updateAbrpApiKey(value: String) {
+        _uiState.update { it.copy(abrpApiKey = value) }
+    }
+
+    fun updateAbrpUserToken(value: String) {
+        _uiState.update { it.copy(abrpUserToken = value) }
+    }
+
+    fun updateAbrpCarModel(value: String) {
+        _uiState.update { it.copy(abrpCarModel = value) }
+    }
+
+    fun updateAbrpIntervalSec(value: String) {
+        _uiState.update { it.copy(abrpIntervalSec = value.filter { ch -> ch.isDigit() }.take(3)) }
+    }
+
+    fun saveAbrpSettings() {
+        val state = _uiState.value
+        viewModelScope.launch {
+            val interval = state.abrpIntervalSec.toIntOrNull()?.coerceIn(5, 120) ?: 12
+            settingsRepository.setString(SettingsRepository.KEY_ABRP_API_KEY, state.abrpApiKey.trim())
+            settingsRepository.setString(SettingsRepository.KEY_ABRP_USER_TOKEN, state.abrpUserToken.trim())
+            settingsRepository.setString(SettingsRepository.KEY_ABRP_CAR_MODEL, state.abrpCarModel.trim())
+            settingsRepository.setString(SettingsRepository.KEY_ABRP_INTERVAL_SEC, interval.toString())
+            val enabled = state.abrpTelemetryEnabled && state.abrpUserToken.isNotBlank()
+            settingsRepository.setString(SettingsRepository.KEY_ABRP_ENABLED, enabled.toString())
+            _uiState.update {
+                it.copy(
+                    abrpTelemetryEnabled = enabled,
+                    abrpIntervalSec = interval.toString(),
+                    abrpSaveStatus = "Сохранено",
+                )
+            }
+            delay(2000)
+            _uiState.update { it.copy(abrpSaveStatus = null) }
         }
     }
 


### PR DESCRIPTION
## Что сделано

Добавлена интеграция с Iternio Telemetry API для отправки живых данных BYDMate в ABRP.

- отправка данных DiPlus и GPS в `https://api.iternio.com/1/tlm/send`;
- формат запроса соответствует документации Iternio: `token` + JSON-объект `tlm`;
- добавлены настройки ABRP в интерфейсе: включение, API-ключ Iternio, токен живых данных, код модели и интервал отправки;
- отправка выполняется из `TrackingService` с ограничением частоты, без блокировки основного цикла опроса.

## Зачем

ABRP сможет получать актуальные SOC, скорость, мощность, координаты и другие доступные показатели автомобиля во время поездки. Это должно улучшить расчёт маршрута, остатка заряда и остановок на зарядку на дальних поездках.

## Проверка

- Сверил формат отправки с документацией Iternio Telemetry API.
- IDE lint по изменённым файлам без ошибок.
- Gradle-сборку локально не запускал: в окружении отсутствует Java Runtime/JDK.