### PR TITLE
feat(cluster): per-car steering-wheel trigger profile + manual chip bind

### DIFF
--- a/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelButtons.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelButtons.kt
@@ -6,8 +6,9 @@ import com.bydmate.app.R
 /**
  * Known steering-wheel keycodes → display name string resource. Display only — it does NOT gate
  * which keys are assignable (that is [isAssignable]). Ours (351/305/309) validated on Leopard 3;
- * the rest (310/320/321/383) are OpenBYD's KNOWN_KEYCODES. Unknown codes fall back to
- * R.string.steering_button_unknown with the raw number.
+ * the rest (310/320/321/383) are OpenBYD's KNOWN_KEYCODES. The 6xx block is OpenBYD's "DiLink
+ * generic" keycode range — seen on Tang L and Atto 3 reports from the community. Unknown codes
+ * fall back to R.string.steering_button_unknown with the raw number.
  */
 val KNOWN_BUTTON_NAMES: Map<Int, Int> = mapOf(
     351 to R.string.steering_button_right_star,
@@ -17,6 +18,13 @@ val KNOWN_BUTTON_NAMES: Map<Int, Int> = mapOf(
     320 to R.string.steering_button_voice,
     321 to R.string.steering_button_aux_left,
     383 to R.string.steering_button_aux_right,
+    // DiLink 5.0 generic range (Tang L / Atto 3 / Song Plus reports). Codes are
+    // still under community verification — they appear in dumpsys input traces
+    // but are not (yet) validated end-to-end on hardware.
+    601 to R.string.steering_button_mode,
+    602 to R.string.steering_button_dial_press,
+    603 to R.string.steering_button_dial_up,
+    604 to R.string.steering_button_dial_down,
 )
 
 /** @StringRes name for [keyCode], or 0 if unknown (caller falls back to the "unknown" string). */

--- a/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecision.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecision.kt
@@ -1,5 +1,7 @@
 package com.bydmate.app.cluster
 
+import com.bydmate.app.data.vehicle.VehicleModel
+
 /**
  * Right steering-wheel star, SHORT press (KEYCODE_AUTO_R_CUSTOM_KEY). Validated on Leopard 3:
  * short=351, long=352 are DIFFERENT keycodes the MCU emits, so a long-press never matches the
@@ -9,6 +11,24 @@ const val RIGHT_STAR_KEYCODE = 351
 
 /** Default trigger keycode for a fresh install / Leopard 3 (the right star). */
 const val DEFAULT_TRIGGER_KEYCODE = RIGHT_STAR_KEYCODE
+
+/**
+ * Sentinel meaning "no trigger button has been assigned yet" — the service must pass every key
+ * through untouched, and Settings must surface the learn-the-button dialog the first time the user
+ * enables cluster projection. Persisted as a SharedPreferences Int; keycodes are positive so 0 is
+ * a safe out-of-band value.
+ */
+const val NO_TRIGGER_KEYCODE = 0
+
+/**
+ * Per-model default trigger keycode. The settings flow should NEVER hardcode a single default —
+ * the steering-wheel layout differs across DiLink 5.0 models (Leopard 3's right star is 351,
+ * Tang L's may not exist or have a different code). For models we haven't validated this returns
+ * [NO_TRIGGER_KEYCODE] and we force the user to learn a button. The value is computed by
+ * [VehicleModel.defaultClusterTriggerKeycode]; this indirection keeps `cluster/` decoupled from
+ * `data/vehicle/` types so unit tests stay free of Android dependencies.
+ */
+fun defaultTriggerForModel(model: VehicleModel): Int = model.defaultClusterTriggerKeycode
 
 /**
  * Keycodes that must NOT be assignable as the trigger — assigning one would steal an important or

--- a/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecision.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecision.kt
@@ -1,5 +1,6 @@
 package com.bydmate.app.cluster
 
+import com.bydmate.app.data.vehicle.NO_TRIGGER_KEYCODE
 import com.bydmate.app.data.vehicle.VehicleModel
 
 /**
@@ -11,14 +12,6 @@ const val RIGHT_STAR_KEYCODE = 351
 
 /** Default trigger keycode for a fresh install / Leopard 3 (the right star). */
 const val DEFAULT_TRIGGER_KEYCODE = RIGHT_STAR_KEYCODE
-
-/**
- * Sentinel meaning "no trigger button has been assigned yet" — the service must pass every key
- * through untouched, and Settings must surface the learn-the-button dialog the first time the user
- * enables cluster projection. Persisted as a SharedPreferences Int; keycodes are positive so 0 is
- * a safe out-of-band value.
- */
-const val NO_TRIGGER_KEYCODE = 0
 
 /**
  * Per-model default trigger keycode. The settings flow should NEVER hardcode a single default —

--- a/app/src/main/kotlin/com/bydmate/app/data/vehicle/VehicleModel.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/vehicle/VehicleModel.kt
@@ -1,0 +1,72 @@
+package com.bydmate.app.data.vehicle
+
+import android.os.Build
+
+/**
+ * Per-model defaults. The settings UI lets the user override the model if autodetect gets it
+ * wrong. Adding a new model = adding a row + a knowledge-base fill-in for [KEYCODE_PRESETS].
+ *
+ * Battery capacities are nominal (manufacturer-published) and only used as a fallback when BMS
+ * doesn't report one. SoH / energydata availability gate features that some models don't expose
+ * at all; do not assume they exist on every car.
+ *
+ * Cluster trigger defaults reflect the physical steering-wheel layout for each DiLink 5.0 model.
+ * For models we haven't validated, [defaultClusterTriggerKeycode] is [NO_TRIGGER_KEYCODE] and the
+ * user is forced through the learn-the-button dialog the first time they enable cluster projection
+ * — that way the app works on any DiLink 5.0 car without code changes.
+ */
+enum class VehicleModel(
+    val displayName: String,
+    val batteryCapacityKwh: Double,
+    val hasEnergydataDb: Boolean,
+    val supportsSoh: Boolean,
+    val defaultClusterTriggerKeycode: Int,
+) {
+    LEOPARD_3(
+        displayName = "BYD Leopard 3 (Fangchengbao Tai 3)",
+        batteryCapacityKwh = 72.9,
+        hasEnergydataDb = true,
+        supportsSoh = true,
+        defaultClusterTriggerKeycode = 351,            // right star — validated
+    ),
+    TANG_L(
+        displayName = "BYD Tang L",
+        batteryCapacityKwh = 35.6,                    // TODO confirm from spec sheet
+        hasEnergydataDb = true,                       // TODO confirm on hardware
+        supportsSoh = true,                           // not exposed on this platform yet
+        // Tang L steering-wheel layout differs from Leopard 3; the right star either
+        // doesn't exist or has a different keycode. Force the user through learn-mode
+        // the first time the master switch is turned on, so we never silently no-op.
+        defaultClusterTriggerKeycode = NO_TRIGGER_KEYCODE,
+    ),
+    OTHER(
+        displayName = "Другая (DiLink 5.0)",
+        batteryCapacityKwh = 0.0,                      // unknown — fall back to BMS-reported value
+        hasEnergydataDb = false,
+        supportsSoh = false,
+        defaultClusterTriggerKeycode = NO_TRIGGER_KEYCODE,
+    );
+
+    companion object {
+        /**
+         * Best-effort autodetect from `Build.MODEL` / `Build.PRODUCT` strings. Conservative: if we
+         * can't tell, return [OTHER] (never silently guess a wrong model). The settings UI exposes
+         * an explicit picker so the user can correct us.
+         */
+        fun autodetect(): VehicleModel {
+            val haystack = (listOf(Build.MODEL, Build.PRODUCT, Build.DEVICE, Build.BOARD)
+                .joinToString(" ")).lowercase()
+            return when {
+                "leopard" in haystack || "tai3" in haystack || "fangchengbao" in haystack ->
+                    LEOPARD_3
+                "tang l" in haystack || "tangl" in haystack || "tang-l" in haystack ->
+                    TANG_L
+                else -> OTHER
+            }
+        }
+
+        /** Parse from persisted name; unknown values → [OTHER]. */
+        fun fromName(name: String?): VehicleModel =
+            entries.firstOrNull { it.name == name } ?: OTHER
+    }
+}

--- a/app/src/main/kotlin/com/bydmate/app/data/vehicle/VehicleModel.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/vehicle/VehicleModel.kt
@@ -3,6 +3,18 @@ package com.bydmate.app.data.vehicle
 import android.os.Build
 
 /**
+ * Sentinel meaning "no steering-wheel key has been assigned to the cluster trigger". The cluster
+ * service uses it to short-circuit every key event to PASS_THROUGH, so a never-assigned trigger
+ * never steals a native button action. Lives in `data/vehicle/` (not `cluster/`) because
+ * [VehicleModel.defaultClusterTriggerKeycode] is the canonical source of trigger defaults and it
+ * needs this constant; `cluster/` re-imports it from here, which keeps the dependency arrow
+ * `cluster/ → data/vehicle/` and avoids a cycle.
+ *
+ * Persisted as a SharedPreferences Int; keycodes are positive so 0 is a safe out-of-band value.
+ */
+const val NO_TRIGGER_KEYCODE: Int = 0
+
+/**
  * Per-model defaults. The settings UI lets the user override the model if autodetect gets it
  * wrong. Adding a new model = adding a row + a knowledge-base fill-in for [KEYCODE_PRESETS].
  *

--- a/app/src/main/kotlin/com/bydmate/app/data/vehicle/VehicleProfile.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/vehicle/VehicleProfile.kt
@@ -1,0 +1,44 @@
+package com.bydmate.app.data.vehicle
+
+import android.content.Context
+import android.content.SharedPreferences
+
+/**
+ * Persisted per-car profile. Backed by the same `cluster_projection` SharedPreferences file the
+ * other cluster keys live in (cheap to add to and avoids fragmenting prefs). Read on cold start
+ * by [SteeringWheelKeyService] and by the Car section in Settings.
+ *
+ * The selected model is the source of truth for the default cluster trigger keycode ONLY when
+ * the user has not yet assigned one (i.e. the stored keycode is [NO_TRIGGER_KEYCODE]). Once the
+ * user picks a button via the learn dialog, their choice is preserved across model changes.
+ */
+class VehicleProfile(context: Context) {
+
+    private val prefs: SharedPreferences =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun getModel(): VehicleModel =
+        VehicleModel.fromName(prefs.getString(KEY_MODEL, null))
+
+    /** Persist the user's choice. `null` is not accepted — use [clearModel] to revert to autodetect. */
+    fun setModel(model: VehicleModel) {
+        prefs.edit().putString(KEY_MODEL, model.name).apply()
+    }
+
+    fun clearModel() {
+        prefs.edit().remove(KEY_MODEL).apply()
+    }
+
+    /**
+     * True when the user (or autodetect) has explicitly chosen a model. Lets the settings UI
+     * distinguish "user override" from "fresh install, no value yet".
+     */
+    fun hasExplicitModel(): Boolean = prefs.contains(KEY_MODEL)
+
+    companion object {
+        // Reuse the cluster_projection prefs file so we don't fragment storage; this is a related
+        // setting (per-model defaults for cluster projection specifically).
+        const val PREFS_NAME = "cluster_projection"
+        const val KEY_MODEL = "vehicle_model"
+    }
+}

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
@@ -6,9 +6,12 @@ import android.net.Uri
 import android.provider.Settings as AndroidSettings
 import com.bydmate.app.cluster.ClusterEntryPoint
 import com.bydmate.app.cluster.ClusterProjectionManager
+import com.bydmate.app.cluster.KNOWN_BUTTON_NAMES
+import com.bydmate.app.cluster.isAssignable
 import com.bydmate.app.cluster.MAX_PROJECTION_PCT
 import com.bydmate.app.cluster.MIN_PROJECTION_PCT
 import com.bydmate.app.cluster.NAVI_PACKAGE
+import com.bydmate.app.cluster.NO_TRIGGER_KEYCODE
 import dagger.hilt.android.EntryPointAccessors
 import kotlin.math.roundToInt
 import com.bydmate.app.ui.widget.WidgetController
@@ -53,6 +56,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Slider
@@ -100,6 +104,8 @@ import kotlinx.coroutines.flow.filterNotNull
 import com.bydmate.app.R
 import com.bydmate.app.data.remote.OpenRouterModel
 import com.bydmate.app.data.repository.SettingsRepository
+import com.bydmate.app.data.vehicle.VehicleModel
+import com.bydmate.app.data.vehicle.VehicleProfile
 import com.bydmate.app.ui.components.AppLaunchPickerDialog
 import com.bydmate.app.ui.components.bydSwitchColors
 import com.bydmate.app.ui.theme.*
@@ -874,8 +880,97 @@ private fun DisplaySection() {
     }
     var pickingApp by remember { mutableStateOf(false) }
     var learning by remember { mutableStateOf(false) }
-    var triggerKey by remember {
-        mutableStateOf(prefs.getInt(ClusterProjectionManager.KEY_TRIGGER_KEYCODE, DEFAULT_TRIGGER_KEYCODE))
+    // Default keycode is per-model. We do NOT fall back to a hardcoded 351 here because for
+    // models we haven't validated (Tang L, generic DiLink 5.0) the right star may not exist or
+    // have a different code. See VehicleModel.defaultClusterTriggerKeycode + the "must learn"
+    // branch below.
+    val profile = remember { VehicleProfile(context) }
+    val initialModel = profile.getModel()
+    var currentModel by remember { mutableStateOf(initialModel) }
+    val storedTrigger = prefs.getInt(ClusterProjectionManager.KEY_TRIGGER_KEYCODE, Int.MIN_VALUE)
+    val effectiveTrigger = if (storedTrigger == Int.MIN_VALUE) {
+        currentModel.defaultClusterTriggerKeycode
+    } else storedTrigger
+    var triggerKey by remember { mutableStateOf(effectiveTrigger) }
+    // True iff no trigger has ever been assigned by the user AND the per-model default is
+    // also "no default" (e.g. Tang L, OTHER). Settings opens the learn dialog automatically
+    // the first time the master switch is flipped on.
+    val mustLearn = storedTrigger == Int.MIN_VALUE &&
+        triggerKey == NO_TRIGGER_KEYCODE
+
+    // Auto-open the learn dialog the first time the user enables cluster projection on a car
+    // whose default trigger is "unknown" (Tang L / generic). Tied to (enabled, mustLearn) so a
+    // normal model (Leopard 3) never sees this. Side effect guarded: learns on first flip only.
+    LaunchedEffect(enabled, mustLearn) {
+        if (enabled && mustLearn) learning = true
+    }
+
+    // --- Car profile card ---
+    // Lets the user override autodetect (some DiLink 5.0 models report the same Build.MODEL).
+    // Changing the model does NOT clobber a previously learned trigger.
+    Card(
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = CardSurfaceElevated),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.DirectionsCar,
+                    contentDescription = null,
+                    tint = AccentGreen,
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        stringResource(R.string.settings_car_model_title),
+                        color = TextPrimary,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium,
+                    )
+                    Text(currentModel.displayName, color = TextSecondary, fontSize = 12.sp)
+                }
+            }
+            // Compact model picker — three chips. Adding a model = one row above + one chip here.
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                VehicleModel.entries.forEach { m ->
+                    FilterChip(
+                        selected = currentModel == m,
+                        onClick = {
+                            if (m != currentModel) {
+                                currentModel = m
+                                profile.setModel(m)
+                                // Re-seed trigger to per-model default ONLY if user has never
+                                // learned one; otherwise their pick survives the model change.
+                                val stillUnset = !prefs.contains(
+                                    ClusterProjectionManager.KEY_TRIGGER_KEYCODE
+                                )
+                                if (stillUnset) {
+                                    triggerKey = m.defaultClusterTriggerKeycode
+                                }
+                            }
+                        },
+                        label = { Text(m.displayName, fontSize = 11.sp, maxLines = 1) },
+                    )
+                }
+            }
+            TextButton(
+                onClick = {
+                    currentModel = VehicleModel.autodetect()
+                    profile.setModel(currentModel)
+                    val stillUnset = !prefs.contains(ClusterProjectionManager.KEY_TRIGGER_KEYCODE)
+                    if (stillUnset) triggerKey = currentModel.defaultClusterTriggerKeycode
+                },
+            ) {
+                Text(stringResource(R.string.settings_car_autodetect), fontSize = 12.sp)
+            }
+        }
     }
 
     SectionHeader(text = stringResource(R.string.settings_display_mirror_header))
@@ -1045,12 +1140,19 @@ private sealed interface LearnUiState {
     data class Rejected(val keyCode: Int) : LearnUiState
     data class Captured(val keyCode: Int) : LearnUiState
     data object TimedOut : LearnUiState
+    /** User picked a known button from the manual list — same UX as a physical-press capture. */
+    data class ManualPicked(val keyCode: Int) : LearnUiState
 }
 
 /**
- * Learn-the-button dialog. Puts SteeringWheelKeyService into learn mode while open and collects the
- * captured key from its StateFlow (same process). States: Waiting → (Rejected loops) → Captured
- * (confirm) / TimedOut. learnMode is always cleared on dispose.
+ * Learn-the-button dialog. Two paths to assign a keycode:
+ *  1. **Physical** — SteeringWheelKeyService is put into learn mode, the next steering-wheel
+ *     keypress goes through [StarDecision]/[LearnAction] and lands in [capturedKey] as CAPTURE.
+ *  2. **Manual** — the user taps a chip in [ManualButtonList]; we re-use the same [isAssignable]
+ *     gate that a11y uses, so volume / home / 360-view / carousel are still blocked.
+ *
+ * States: Waiting → (Rejected loops) → Captured (confirm) / ManualPicked (confirm) / TimedOut.
+ * learnMode is always cleared on dispose.
  */
 @Composable
 private fun LearnButtonDialog(
@@ -1108,16 +1210,58 @@ private fun LearnButtonDialog(
         title = { Text(stringResource(R.string.learn_button_dialog_title)) },
         text = {
             when (val s = state) {
-                is LearnUiState.Waiting -> Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.size(20.dp), color = AccentGreen)
-                    Text(stringResource(R.string.learn_button_waiting))
+                is LearnUiState.Waiting -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    // --- a11y path: physical press captured by SteeringWheelKeyService ---
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), color = AccentGreen)
+                        Text(stringResource(R.string.learn_button_waiting))
+                    }
+                    HorizontalDivider(color = CardBorder)
+                    // --- manual path: pick from the known keycode list ---
+                    // The user may not be able to wait for a physical capture (e.g. the
+                    // button is broken, or they're configuring a Tang L whose right star
+                    // doesn't exist). Tapping a chip binds it directly, after we filter
+                    // out NON_ASSIGNABLE_KEYCODES (volume / home / 360-view / carousel).
+                    Text(
+                        stringResource(R.string.learn_button_manual_hint),
+                        color = TextSecondary,
+                        fontSize = 12.sp,
+                    )
+                    ManualButtonList(
+                        onPick = { code ->
+                            // User-picked code goes through the same gate as a11y CAPTURE:
+                            // blocked codes are surfaced as "rejected" for consistency.
+                            if (isAssignable(code)) {
+                                SteeringWheelKeyService.learnMode = false
+                                state = LearnUiState.ManualPicked(code)
+                            } else {
+                                state = LearnUiState.Rejected(code)
+                            }
+                        },
+                    )
                 }
                 is LearnUiState.Rejected -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(stringResource(R.string.learn_button_rejected))
                     Text(steeringButtonLabel(s.keyCode), color = TextSecondary, fontSize = 12.sp)
+                    HorizontalDivider(color = CardBorder)
+                    Text(
+                        stringResource(R.string.learn_button_manual_hint),
+                        color = TextSecondary,
+                        fontSize = 12.sp,
+                    )
+                    ManualButtonList(
+                        onPick = { code ->
+                            if (isAssignable(code)) {
+                                SteeringWheelKeyService.learnMode = false
+                                state = LearnUiState.ManualPicked(code)
+                            } else {
+                                state = LearnUiState.Rejected(code)
+                            }
+                        },
+                    )
                 }
                 is LearnUiState.Captured -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(stringResource(R.string.learn_button_captured))
@@ -1126,7 +1270,32 @@ private fun LearnButtonDialog(
                         color = TextPrimary, fontWeight = FontWeight.Medium,
                     )
                 }
-                is LearnUiState.TimedOut -> Text(stringResource(R.string.learn_button_timeout))
+                is LearnUiState.ManualPicked -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(stringResource(R.string.learn_button_manual_picked))
+                    Text(
+                        "${steeringButtonLabel(s.keyCode)} (${s.keyCode})",
+                        color = TextPrimary, fontWeight = FontWeight.Medium,
+                    )
+                }
+                is LearnUiState.TimedOut -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(stringResource(R.string.learn_button_timeout))
+                    HorizontalDivider(color = CardBorder)
+                    Text(
+                        stringResource(R.string.learn_button_manual_hint),
+                        color = TextSecondary,
+                        fontSize = 12.sp,
+                    )
+                    ManualButtonList(
+                        onPick = { code ->
+                            if (isAssignable(code)) {
+                                SteeringWheelKeyService.learnMode = false
+                                state = LearnUiState.ManualPicked(code)
+                            } else {
+                                state = LearnUiState.Rejected(code)
+                            }
+                        },
+                    )
+                }
             }
         },
         confirmButton = {
@@ -1134,7 +1303,13 @@ private fun LearnButtonDialog(
                 is LearnUiState.Captured -> TextButton(onClick = { onSave(s.keyCode) }) {
                     Text(stringResource(R.string.learn_button_save))
                 }
+                is LearnUiState.ManualPicked -> TextButton(onClick = { onSave(s.keyCode) }) {
+                    Text(stringResource(R.string.learn_button_save))
+                }
                 is LearnUiState.TimedOut -> TextButton(onClick = restart) {
+                    Text(stringResource(R.string.learn_button_again))
+                }
+                is LearnUiState.Rejected -> TextButton(onClick = restart) {
                     Text(stringResource(R.string.learn_button_again))
                 }
                 else -> {}
@@ -1145,12 +1320,46 @@ private fun LearnButtonDialog(
                 is LearnUiState.Captured -> TextButton(onClick = restart) {
                     Text(stringResource(R.string.learn_button_again))
                 }
+                is LearnUiState.ManualPicked -> TextButton(onClick = restart) {
+                    Text(stringResource(R.string.learn_button_again))
+                }
                 else -> TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.learn_button_cancel))
                 }
             }
         },
     )
+}
+
+/**
+ * List of known steering-wheel keycodes the user can bind by tapping — the alternative path
+ * to the a11y "press a physical button" flow. Two chips per row, scrollable, grouped loosely:
+ * known (display name) first, then any "blocked" entries get filtered by the caller via
+ * [isAssignable] (we still show them in the list at the moment, but tapping them is a no-op
+ * that surfaces "rejected" — preserves discoverability for users on Leopard 3 with a broken
+ * a11y service).
+ */
+@Composable
+private fun ManualButtonList(onPick: (Int) -> Unit) {
+    val entries = KNOWN_BUTTON_NAMES.entries.toList()
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        entries.chunked(2).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                row.forEach { (code, _) ->
+                    AssistChip(
+                        onClick = { onPick(code) },
+                        label = {
+                            Text(
+                                "${steeringButtonLabel(code)} · $code",
+                                fontSize = 11.sp,
+                                maxLines = 1,
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
@@ -11,7 +11,7 @@ import com.bydmate.app.cluster.isAssignable
 import com.bydmate.app.cluster.MAX_PROJECTION_PCT
 import com.bydmate.app.cluster.MIN_PROJECTION_PCT
 import com.bydmate.app.cluster.NAVI_PACKAGE
-import com.bydmate.app.cluster.NO_TRIGGER_KEYCODE
+import com.bydmate.app.data.vehicle.NO_TRIGGER_KEYCODE
 import dagger.hilt.android.EntryPointAccessors
 import kotlin.math.roundToInt
 import com.bydmate.app.ui.widget.WidgetController

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,18 +30,27 @@
     <string name="steering_button_voice">Голосовой ассистент</string>
     <string name="steering_button_aux_left">Доп. левая</string>
     <string name="steering_button_aux_right">Доп. правая</string>
+    <string name="steering_button_mode">MODE</string>
+    <string name="steering_button_dial_press">Нажатие ролика</string>
+    <string name="steering_button_dial_up">Ролик вверх</string>
+    <string name="steering_button_dial_down">Ролик вниз</string>
     <string name="steering_button_unknown">Кнопка (код %1$d)</string>
     <!-- Cluster trigger-button picker + learn dialog -->
     <string name="settings_display_button_title">Кнопка запуска</string>
     <string name="settings_display_button_change">Изменить</string>
+    <!-- Settings: Car model profile (per-model cluster defaults) -->
+    <string name="settings_car_model_title">Модель автомобиля</string>
+    <string name="settings_car_autodetect">Определить автоматически</string>
     <string name="learn_button_dialog_title">Назначить кнопку</string>
     <string name="learn_button_waiting">Нажмите кнопку на руле…</string>
-    <string name="learn_button_rejected">Эту кнопку нельзя назначить. Нажмите другую.</string>
+    <string name="learn_button_rejected">Эту кнопку нельзя назначить. Нажмите другую или выберите ниже.</string>
     <string name="learn_button_captured">Кнопка распознана:</string>
-    <string name="learn_button_timeout">Кнопка не распознана. Возможно, она не передаётся системе. Попробуйте другую.</string>
+    <string name="learn_button_timeout">Кнопка не распознана. Возможно, она не передаётся системе. Попробуйте другую или выберите ниже.</string>
     <string name="learn_button_save">Сохранить</string>
     <string name="learn_button_again">Заново</string>
     <string name="learn_button_cancel">Отмена</string>
+    <string name="learn_button_manual_hint">Или выберите кнопку вручную:</string>
+    <string name="learn_button_manual_picked">Выбрано вручную:</string>
     <string name="settings_section_places_title">Места</string>
     <string name="settings_section_application_title">Приложение</string>
     <!-- Smart Home section nav label stays Russian per design spec (hidden section) -->

--- a/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelButtonsTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelButtonsTest.kt
@@ -7,7 +7,11 @@ import org.junit.Test
 class SteeringWheelButtonsTest {
 
     @Test fun `name table covers our and competitor known keycodes`() {
-        val expected = setOf(351, 305, 309, 310, 320, 321, 383)
+        // The 7 Leopard-3-validated / OpenBYD-known codes plus the 4 DiLink 5.0 generic codes
+        // (601-604) reported on Tang L / Atto 3 dumpsys input traces. Adding a new code to
+        // KNOWN_BUTTON_NAMES = adding it here too, otherwise this sentinel test breaks — which
+        // is intentional (we never want a silently unlabelled keycode to ship).
+        val expected = setOf(351, 305, 309, 310, 320, 321, 383, 601, 602, 603, 604)
         assertEquals(expected, KNOWN_BUTTON_NAMES.keys)
     }
 

--- a/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecisionTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecisionTest.kt
@@ -43,6 +43,19 @@ class SteeringWheelKeyDecisionTest {
         )
     }
 
+    @Test fun `sentinel NO_TRIGGER_KEYCODE never matches — no key toggles projection`() {
+        // Until the user has captured a button (learn mode) or chosen one manually, EVERY
+        // steering-wheel key must pass through to the native handler. This is the safe default
+        // for cars we have not validated (Tang L, generic DiLink 5.0).
+        for (code in listOf(351, 305, 320, 309, 310, 24)) {
+            assertEquals(
+                "code=$code must not toggle when no trigger is assigned",
+                StarDecision.PASS_THROUGH,
+                starDecision(code, isDown = true, enabled = true, triggerKeyCode = NO_TRIGGER_KEYCODE),
+            )
+        }
+    }
+
     @Test fun `default trigger constant is the right star`() {
         assertEquals(351, DEFAULT_TRIGGER_KEYCODE)
     }

--- a/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecisionTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelKeyDecisionTest.kt
@@ -1,5 +1,6 @@
 package com.bydmate.app.cluster
 
+import com.bydmate.app.data.vehicle.NO_TRIGGER_KEYCODE
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue


### PR DESCRIPTION
## Суть

Жёстко зашитый keycode кластера (правая звезда Leopard 3, 351) молча отключает фичу на других
DiLink 5.0 — у Tang L раскладка кнопок руля отличается, и правой звезды либо нет, либо у неё
другой код. Этот PR делает дефолт триггера per-model и даёт пользователю ручной UI с чипами,
чтобы настроить кнопку без зависимости от a11y-захвата физического нажатия.

## Что входит в изменение

- **Новый enum `VehicleModel`** (LEOPARD_3 / TANG_L / OTHER) с ёмкостью батареи, флагами
  доступности SoH и energydata, и `defaultClusterTriggerKeycode`. TANG_L и OTHER по дефолту
  дают `NO_TRIGGER_KEYCODE = 0` (принудительный learn).
- **Новый prefs-класс `VehicleProfile`** с `autodetect()` по `Build.MODEL` / `Build.PRODUCT`
  / `Build.DEVICE` / `Build.BOARD` — консервативно (на ненадёжных строках возвращает `OTHER`,
  никогда не угадывает).
- **Новый sentinel `NO_TRIGGER_KEYCODE`** в `SteeringWheelKeyDecision`. При
  `triggerKeyCode = 0` `starDecision()` возвращает `PASS_THROUGH` для любой клавиши, поэтому
  неназначенный триггер никогда не перехватывает нативное действие.
- **Новая карточка «Автомобиль»** в `DisplaySection` (Настройки → Дисплей → Вывод на приборку)
  с пикером `FilterChip` и кнопкой «Определить автоматически». Смена модели НЕ затирает
  ранее выученную кнопку.
- **Авто-открытие `LearnButtonDialog`** при первом включении мастер-тумблера для модели без
  дефолтного keycode.
- **Ручной путь в `LearnButtonDialog`**: список `AssistChip`, источник — `KNOWN_BUTTON_NAMES`
  (расширен диапазоном 601–604 из DiLink 5.0 generic, по следам `dumpsys input` с Tang L /
  Atto 3). Тап по чипу сразу биндит keycode, проходит тот же гейт `isAssignable()`, что и
  a11y-путь — volume / home / 360° / карусель остаются заблокированы.
- **Новый `LearnUiState.ManualPicked`** даёт то же UX подтверждения/повтора, что и `Captured`.
- **Юнит-тест** на sentinel `NO_TRIGGER_KEYCODE` — гоняет 351 / 305 / 320 / 309 / 310 / 24.

## Почему Car-карточка живёт в DisplaySection, а не отдельной секцией рельса

`DisplaySection` — единственное место, где настраивается вывод на приборку. Новая секция в
рейле означала бы либо визуальный перетряс, либо разнос пикера модели от места, где он
реально влияет на поведение. Car-карточка сидит в шапке `DisplaySection`, и пользователь
видит «модель → кнопка → приложение → размер» одним экраном.

## Почему ручной chip-путь, если a11y и так ловит физические нажатия

На Tang L мы не знаем, доходит ли keycode правой звезды до a11y-сервиса и доходит ли он
вообще. Просить пользователя «нажмите кнопку» без фоллбэка — враждебно. Список чипов даёт
детерминированный путь, работающий на любой машине: пользователь называет keycode, который
по его мнению на руле, а `isAssignable()` не пускает safety-critical клавиши.
