### PR TITLE
feat(cluster): manual chip-picker fallback in LearnButtonDialog

### DIFF
--- a/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelButtons.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/SteeringWheelButtons.kt
@@ -6,8 +6,9 @@ import com.bydmate.app.R
 /**
  * Known steering-wheel keycodes → display name string resource. Display only — it does NOT gate
  * which keys are assignable (that is [isAssignable]). Ours (351/305/309) validated on Leopard 3;
- * the rest (310/320/321/383) are OpenBYD's KNOWN_KEYCODES. Unknown codes fall back to
- * R.string.steering_button_unknown with the raw number.
+ * the rest (310/320/321/383) are OpenBYD's KNOWN_KEYCODES. The 601-604 block is the DiLink 5.0
+ * generic range reported on Tang L / Atto 3 dumpsys input traces — community-verified, not yet
+ * validated end-to-end. Unknown codes fall back to R.string.steering_button_unknown.
  */
 val KNOWN_BUTTON_NAMES: Map<Int, Int> = mapOf(
     351 to R.string.steering_button_right_star,
@@ -17,6 +18,10 @@ val KNOWN_BUTTON_NAMES: Map<Int, Int> = mapOf(
     320 to R.string.steering_button_voice,
     321 to R.string.steering_button_aux_left,
     383 to R.string.steering_button_aux_right,
+    601 to R.string.steering_button_mode,
+    602 to R.string.steering_button_dial_press,
+    603 to R.string.steering_button_dial_up,
+    604 to R.string.steering_button_dial_down,
 )
 
 /** @StringRes name for [keyCode], or 0 if unknown (caller falls back to the "unknown" string). */

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
@@ -1203,6 +1203,11 @@ private fun LearnButtonDialog(
  * AssistChip list sourced from KNOWN_BUTTON_NAMES. Tapping a chip binds the keycode without
  * needing the a11y service to capture a physical press. Useful fallback when the keycode is
  * not exposed to the accessibility filter (some DiLink 5.0 models, e.g. Tang L).
+ *
+ * Only [isAssignable] keycodes are listed — showing carousel (309) / 360-view (310), which are
+ * in NON_ASSIGNABLE_KEYCODES, would let the user tap a chip that just bounces to "can't assign".
+ * The physical-press path still surfaces those as Rejected (the user might press one by mistake),
+ * but the manual list should only offer choices that actually work.
  */
 @Composable
 private fun ManualButtonList(onPick: (Int) -> Unit) {
@@ -1212,10 +1217,10 @@ private fun ManualButtonList(onPick: (Int) -> Unit) {
             color = TextSecondary,
             fontSize = 12.sp,
         )
-        val entries = KNOWN_BUTTON_NAMES.entries.toList()
+        val entries = KNOWN_BUTTON_NAMES.keys.filter { isAssignable(it) }.sorted()
         entries.chunked(2).forEach { row ->
             Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                row.forEach { (code, _) ->
+                row.forEach { code ->
                     AssistChip(
                         onClick = { onPick(code) },
                         label = {

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
@@ -6,9 +6,11 @@ import android.net.Uri
 import android.provider.Settings as AndroidSettings
 import com.bydmate.app.cluster.ClusterEntryPoint
 import com.bydmate.app.cluster.ClusterProjectionManager
+import com.bydmate.app.cluster.KNOWN_BUTTON_NAMES
 import com.bydmate.app.cluster.MAX_PROJECTION_PCT
 import com.bydmate.app.cluster.MIN_PROJECTION_PCT
 import com.bydmate.app.cluster.NAVI_PACKAGE
+import com.bydmate.app.cluster.isAssignable
 import dagger.hilt.android.EntryPointAccessors
 import kotlin.math.roundToInt
 import com.bydmate.app.ui.widget.WidgetController
@@ -53,6 +55,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Slider
@@ -1045,12 +1048,20 @@ private sealed interface LearnUiState {
     data class Rejected(val keyCode: Int) : LearnUiState
     data class Captured(val keyCode: Int) : LearnUiState
     data object TimedOut : LearnUiState
+    /** User picked a keycode from the manual chip list (the a11y CAPTURE path was unreachable). */
+    data class ManualPicked(val keyCode: Int) : LearnUiState
 }
 
 /**
- * Learn-the-button dialog. Puts SteeringWheelKeyService into learn mode while open and collects the
- * captured key from its StateFlow (same process). States: Waiting → (Rejected loops) → Captured
- * (confirm) / TimedOut. learnMode is always cleared on dispose.
+ * Learn-the-button dialog. Two paths to assign a keycode:
+ *  1. **Physical** — SteeringWheelKeyService is put into learn mode; the next steering-wheel
+ *     keypress goes through [StarDecision]/[LearnAction] and lands in [capturedKey] as CAPTURE.
+ *  2. **Manual** — the user taps a chip in [ManualButtonList]; we re-use the same
+ *     [isAssignable] gate that a11y uses, so volume / home / 360-view / carousel are still
+ *     blocked.
+ *
+ * States: Waiting → (Rejected loops) → Captured / ManualPicked (confirm) → TimedOut.
+ * learnMode is always cleared on dispose.
  */
 @Composable
 private fun LearnButtonDialog(
@@ -1103,21 +1114,37 @@ private fun LearnButtonDialog(
         state = LearnUiState.Waiting
     }
 
+    // Tap a chip → same gate as the a11y path (isAssignable), so volume / home / 360-view /
+    // carousel are still blocked. Successful pick disables learnMode (we don't need the
+    // accessibility filter any more — the user has chosen).
+    val pickManual: (Int) -> Unit = { code ->
+        if (isAssignable(code)) {
+            SteeringWheelKeyService.learnMode = false
+            state = LearnUiState.ManualPicked(code)
+        } else {
+            state = LearnUiState.Rejected(code)
+        }
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.learn_button_dialog_title)) },
         text = {
             when (val s = state) {
-                is LearnUiState.Waiting -> Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    CircularProgressIndicator(modifier = Modifier.size(20.dp), color = AccentGreen)
-                    Text(stringResource(R.string.learn_button_waiting))
+                is LearnUiState.Waiting -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), color = AccentGreen)
+                        Text(stringResource(R.string.learn_button_waiting))
+                    }
+                    ManualButtonList(onPick = pickManual)
                 }
                 is LearnUiState.Rejected -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(stringResource(R.string.learn_button_rejected))
                     Text(steeringButtonLabel(s.keyCode), color = TextSecondary, fontSize = 12.sp)
+                    ManualButtonList(onPick = pickManual)
                 }
                 is LearnUiState.Captured -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(stringResource(R.string.learn_button_captured))
@@ -1126,7 +1153,17 @@ private fun LearnButtonDialog(
                         color = TextPrimary, fontWeight = FontWeight.Medium,
                     )
                 }
-                is LearnUiState.TimedOut -> Text(stringResource(R.string.learn_button_timeout))
+                is LearnUiState.ManualPicked -> Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(stringResource(R.string.learn_button_manual_picked))
+                    Text(
+                        "${steeringButtonLabel(s.keyCode)} (${s.keyCode})",
+                        color = TextPrimary, fontWeight = FontWeight.Medium,
+                    )
+                }
+                is LearnUiState.TimedOut -> Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text(stringResource(R.string.learn_button_timeout))
+                    ManualButtonList(onPick = pickManual)
+                }
             }
         },
         confirmButton = {
@@ -1134,7 +1171,13 @@ private fun LearnButtonDialog(
                 is LearnUiState.Captured -> TextButton(onClick = { onSave(s.keyCode) }) {
                     Text(stringResource(R.string.learn_button_save))
                 }
+                is LearnUiState.ManualPicked -> TextButton(onClick = { onSave(s.keyCode) }) {
+                    Text(stringResource(R.string.learn_button_save))
+                }
                 is LearnUiState.TimedOut -> TextButton(onClick = restart) {
+                    Text(stringResource(R.string.learn_button_again))
+                }
+                is LearnUiState.Rejected -> TextButton(onClick = restart) {
                     Text(stringResource(R.string.learn_button_again))
                 }
                 else -> {}
@@ -1145,12 +1188,48 @@ private fun LearnButtonDialog(
                 is LearnUiState.Captured -> TextButton(onClick = restart) {
                     Text(stringResource(R.string.learn_button_again))
                 }
+                is LearnUiState.ManualPicked -> TextButton(onClick = restart) {
+                    Text(stringResource(R.string.learn_button_again))
+                }
                 else -> TextButton(onClick = onDismiss) {
                     Text(stringResource(R.string.learn_button_cancel))
                 }
             }
         },
     )
+}
+
+/**
+ * AssistChip list sourced from KNOWN_BUTTON_NAMES. Tapping a chip binds the keycode without
+ * needing the a11y service to capture a physical press. Useful fallback when the keycode is
+ * not exposed to the accessibility filter (some DiLink 5.0 models, e.g. Tang L).
+ */
+@Composable
+private fun ManualButtonList(onPick: (Int) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            stringResource(R.string.learn_button_manual_hint),
+            color = TextSecondary,
+            fontSize = 12.sp,
+        )
+        val entries = KNOWN_BUTTON_NAMES.entries.toList()
+        entries.chunked(2).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                row.forEach { (code, _) ->
+                    AssistChip(
+                        onClick = { onPick(code) },
+                        label = {
+                            Text(
+                                "${steeringButtonLabel(code)} · $code",
+                                fontSize = 11.sp,
+                                maxLines = 1,
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <string name="steering_button_voice">Голосовой ассистент</string>
     <string name="steering_button_aux_left">Доп. левая</string>
     <string name="steering_button_aux_right">Доп. правая</string>
+    <string name="steering_button_mode">MODE</string>
+    <string name="steering_button_dial_press">Нажатие ролика</string>
+    <string name="steering_button_dial_up">Ролик вверх</string>
+    <string name="steering_button_dial_down">Ролик вниз</string>
     <string name="steering_button_unknown">Кнопка (код %1$d)</string>
     <!-- Cluster trigger-button picker + learn dialog -->
     <string name="settings_display_button_title">Кнопка запуска</string>
@@ -38,10 +42,12 @@
     <string name="learn_button_waiting">Нажмите кнопку на руле…</string>
     <string name="learn_button_rejected">Эту кнопку нельзя назначить. Нажмите другую.</string>
     <string name="learn_button_captured">Кнопка распознана:</string>
-    <string name="learn_button_timeout">Кнопка не распознана. Возможно, она не передаётся системе. Попробуйте другую.</string>
+    <string name="learn_button_timeout">Кнопка не распознана. Возможно, она не передаётся системе. Попробуйте другую или выберите ниже.</string>
     <string name="learn_button_save">Сохранить</string>
     <string name="learn_button_again">Заново</string>
     <string name="learn_button_cancel">Отмена</string>
+    <string name="learn_button_manual_hint">Или выберите кнопку вручную:</string>
+    <string name="learn_button_manual_picked">Выбрано вручную:</string>
     <string name="settings_section_places_title">Места</string>
     <string name="settings_section_application_title">Приложение</string>
     <!-- Smart Home section nav label stays Russian per design spec (hidden section) -->

--- a/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelButtonsTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/cluster/SteeringWheelButtonsTest.kt
@@ -7,7 +7,11 @@ import org.junit.Test
 class SteeringWheelButtonsTest {
 
     @Test fun `name table covers our and competitor known keycodes`() {
-        val expected = setOf(351, 305, 309, 310, 320, 321, 383)
+        // 7 Leopard-3-validated / OpenBYD-known codes + 4 DiLink 5.0 generic codes (601-604)
+        // reported on Tang L / Atto 3 dumpsys input traces. Adding a new keycode to
+        // KNOWN_BUTTON_NAMES without listing it here breaks the test on purpose — we never want
+        // a silently unlabelled keycode to ship.
+        val expected = setOf(351, 305, 309, 310, 320, 321, 383, 601, 602, 603, 604)
         assertEquals(expected, KNOWN_BUTTON_NAMES.keys)
     }
 


### PR DESCRIPTION
## Суть

Продолжение закрытого #47

## Что добавлено 

- **`LearnButtonDialog` получает ручной путь назначения**: список `AssistChip`, источник — `KNOWN_BUTTON_NAMES`. Тап по чипу сразу биндит keycode, проходит тот же гейт `isAssignable()`, что и a11y-путь — volume / home / 360° / карусель остаются заблокированы. Список виден в каждом состоянии диалога (`Waiting`, `Rejected`, `TimedOut`) — пользователь может переключиться на ручной выбор в любой момент.

- **Новый `LearnUiState.ManualPicked`** — то же UX подтверждения/повтора, что и `Captured`. Никаких новых кнопок, тот же «Сохранить / Заново».

- **`KNOWN_BUTTON_NAMES` расширен с 7 до 11 записей**: четыре DiLink 5.0 generic-кода (`601` = MODE, `602` = нажатие ролика, `603` = ролик вверх, `604` = ролик вниз), обнаруженные на Tang L / Atto 3 в `dumpsys input`. Новые строки в `strings.xml` на русском (en/zh проваливаются на русский через Android-resource fallback).

- **Второй коммит — само-ревью поймал UX-баг**: исходный chip-лист рендерил **все** записи, включая карусель (309) и 360° (310) из `NON_ASSIGNABLE_KEYCODES`. Тап по ним уходил в «нельзя назначить» — запутывающее поведение. Теперь chip-лист фильтруется по `isAssignable()` и сортируется. Физический путь **не** тронут: он по-прежнему показывает случайное нажатие заблокированной кнопки как Rejected (этот путь реагирует на то, что нажал пользователь, а не предлагает меню).

- **`SteeringWheelButtonsTest`** обновлён: требует 11 ключей, а не 7. Дополнительно работает как sentinel — без тега нельзя закоммитить новый keycode.

## Что PR **не** делает (намеренно, по ревью #47)

- Нет per-car профиля, `VehicleModel`, `VehicleProfile`, автодетекта.
- Нет sentinel `NO_TRIGGER_KEYCODE` и правок дефолта в рантайме. `DEFAULT_TRIGGER_KEYCODE = 351` в `SteeringWheelKeyDecision` остаётся нетронутым.
- Нет нового UI настроек, нет Car-карточки, нет авто-open логики.
- `SteeringWheelKeyService` не меняется.

## План проверки

- `./gradlew :app:assembleDebug` — **BUILD SUCCESSFUL**, APK чисто собирается поверх `main` (v3.1.1).
- `./gradlew :app:testDebugUnitTest --tests "com.bydmate.app.cluster.*"` — **BUILD SUCCESSFUL**, все cluster-тесты зелёные.
- Вручную: установить на любую DiLink 5.0-машину, открыть Настройки → Дисплей → «Кнопка запуска», в диалоге увидеть под спиннером «Нажмите кнопку на руле…» список чипов «Или выберите кнопку вручную», тапнуть, сохранить, проверить что в `KEY_TRIGGER_KEYCODE` записан новый keycode и нажатие выбранной физической кнопки переключает приборку.
