### PR TITLE
feat(cluster): auto-enable DiLink 5 full-screen projection via AutoContainer

### DIFF
--- a/app/src/main/kotlin/com/bydmate/app/cluster/ClusterProjectionManager.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/ClusterProjectionManager.kt
@@ -58,6 +58,11 @@ object ClusterProjectionManager {
     private const val OVERLAY_TYPE = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY  // 2038, minSdk 29
     private const val OVERLAY_FLAGS = 264                     // FLAG_NOT_FOCUSABLE(8) | FLAG_LAYOUT_IN_SCREEN(256)
     private const val SURFACE_TIMEOUT_MS = 3000L              // give up if the overlay Surface never gets created
+    // DiLink 5 full-screen projection (AutoContainer sendInfo) timings.
+    private const val FULLSCREEN_SETTLE_MS = 500L             // let Qt switch into projection mode after sendInfo(16)
+    private const val CLUSTER_DISPLAY_RETRY_TIMEOUT_MS = 3000L // poll window for the cluster display after sendInfo(16)
+    private const val CLUSTER_DISPLAY_POLL_MS = 300L          // poll interval within the retry window
+    private const val RESTORE_STEP_DELAY_MS = 1000L           // pause between sendInfo(18) and sendInfo(0) on restore
 
     const val PREFS_NAME = "cluster_projection"
     // Master enable for star-controlled projection (settings switch). Read by SteeringWheelKeyService.
@@ -78,6 +83,10 @@ object ClusterProjectionManager {
     // App to project onto the cluster (default Yandex Navi). Label is cached only for the settings row.
     const val KEY_TARGET_PACKAGE = "target_package"
     const val KEY_TARGET_LABEL = "target_label"
+    // Auto-enable the system full-screen projection mode on DiLink 5 before projecting (sendInfo 16).
+    const val KEY_AUTO_ENABLE_FULLSCREEN = "auto_enable_fullscreen"
+    // Restore the native cluster when projection stops (sendInfo 18 → 0).
+    const val KEY_RESTORE_NATIVE_ON_STOP = "restore_native_on_stop"
     // Last VirtualDisplay id we created. Persisted so a fresh app process can release the display
     // a prior (dead) process left orphaned in the long-lived daemon, instead of leaking it.
     private const val KEY_LAST_VD_ID = "last_vd_id"
@@ -271,6 +280,16 @@ object ClusterProjectionManager {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
             .getString(KEY_TARGET_PACKAGE, NAVI_PACKAGE) ?: NAVI_PACKAGE
 
+    /** Whether to auto-enable the DiLink 5 system full-screen projection (sendInfo 16) before projecting. */
+    private fun autoEnableFullscreen(context: Context): Boolean =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_AUTO_ENABLE_FULLSCREEN, false)
+
+    /** Whether to restore the native cluster (sendInfo 18 → 0) when projection stops. */
+    private fun restoreNativeOnStop(context: Context): Boolean =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_RESTORE_NATIVE_ON_STOP, false)
+
     /** Persist the user's chosen trigger keycode (from the learn-button dialog). */
     fun setTriggerKeyCode(context: Context, keyCode: Int) {
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -296,6 +315,14 @@ object ClusterProjectionManager {
         }
     }
 
+    /** Restore the native cluster: sendInfo(18) → pause → sendInfo(0). cmd=0 alone is not enough. */
+    private suspend fun restoreNativeCluster(helper: HelperClient) {
+        val stopped = helper.stopClusterProjection()
+        delay(RESTORE_STEP_DELAY_MS)
+        val refreshed = helper.refreshNativeClusterStream()
+        Log.i(TAG, "restoreNativeCluster: stop(18)=$stopped refresh(0)=$refreshed")
+    }
+
     /** Caller MUST hold [mutex]. Sets currentMode = mode only on full success, else OFF. */
     private suspend fun applyModeLocked(
         context: Context, mode: ClusterMode, helper: HelperClient, bootstrap: HelperBootstrap,
@@ -304,6 +331,9 @@ object ClusterProjectionManager {
             ClusterMode.OFF -> {
                 pullBackToMain(context, helper, focus = true)
                 hideOverlay(helper)
+                if (restoreNativeOnStop(context)) {
+                    restoreNativeCluster(helper)   // sendInfo(18) → delay → sendInfo(0)
+                }
                 projectedPackage = null
                 currentMode = ClusterMode.OFF
             }
@@ -333,7 +363,20 @@ object ClusterProjectionManager {
         if (!ensureOverlayPermission(context, helper)) {
             Log.e(TAG, "overlay permission unavailable; aborting projection"); return false
         }
-        val display = resolveClusterDisplay(context) ?: run {
+        // Enable the DiLink 5 system full-screen projection mode before looking up the cluster
+        // display. The XDJAScreenProjection display appears/switches asynchronously after sendInfo(16),
+        // so we retry the lookup for a few seconds instead of failing immediately.
+        val fullscreenRequested = autoEnableFullscreen(context)
+        if (fullscreenRequested) {
+            val ok = helper.enableClusterFullscreen()
+            // WARN on failure: the projection continues (the display may already be in projection
+            // mode), but a false here is the likely cause of a blank/native cluster.
+            if (ok) Log.i(TAG, "auto-enable DL5 fullscreen (sendInfo 16): ok=true")
+            else Log.w(TAG, "auto-enable DL5 fullscreen (sendInfo 16) failed; projection may not show")
+            delay(FULLSCREEN_SETTLE_MS)
+        }
+        val display = (if (fullscreenRequested) resolveClusterDisplayWithRetry(context)
+                       else resolveClusterDisplay(context)) ?: run {
             Log.e(TAG, "cluster display not found"); return false
         }
         val (widthPct, heightPct) = readSizePct(context)
@@ -418,6 +461,21 @@ object ClusterProjectionManager {
             Log.i(TAG, "cluster display id=${match.displayId} ${clusterWidth}x$clusterHeight dpi=$clusterDensityDpi")
         }
         return match
+    }
+
+    /**
+     * After sendInfo(16) the cluster display appears/switches asynchronously, so poll every 300ms up
+     * to ~3s for the named XDJAScreenProjection display. On timeout we fall back to whatever
+     * [resolveClusterDisplay] returns (it already falls back to DEFAULT_CLUSTER_DISPLAY_ID).
+     */
+    private suspend fun resolveClusterDisplayWithRetry(context: Context): Display? {
+        val deadline = android.os.SystemClock.uptimeMillis() + CLUSTER_DISPLAY_RETRY_TIMEOUT_MS
+        while (android.os.SystemClock.uptimeMillis() < deadline) {
+            val d = resolveClusterDisplay(context)
+            if (d != null && d.name.contains("XDJAScreenProjection", ignoreCase = true)) return d
+            delay(CLUSTER_DISPLAY_POLL_MS)
+        }
+        return resolveClusterDisplay(context)
     }
 
     /**

--- a/app/src/main/kotlin/com/bydmate/app/data/vehicle/HelperClient.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/vehicle/HelperClient.kt
@@ -67,6 +67,14 @@ interface HelperClient {
     /** Disable ([hidden]=true) or re-enable the native BYD assistant family via `pm disable-user/enable`
      *  under shell uid. Daemon-whitelisted to com.byd.autovoice (+ .engine/.tts). Reversible. */
     suspend fun setAppHidden(packageName: String, hidden: Boolean): Boolean
+
+    /** Enable DiLink 5 full-screen cluster projection: AutoContainer.sendInfo(1000, 16, "").
+     *  Daemon-whitelisted to info in {16, 18, 0}. */
+    suspend fun enableClusterFullscreen(): Boolean
+    /** Stop cluster projection: AutoContainer.sendInfo(1000, 18, ""). */
+    suspend fun stopClusterProjection(): Boolean
+    /** Refresh/restore the native cluster video stream: AutoContainer.sendInfo(1000, 0, ""). */
+    suspend fun refreshNativeClusterStream(): Boolean
 }
 
 @Singleton
@@ -160,6 +168,17 @@ open class HelperClientImpl @Inject constructor() : HelperClient {
         statusOk(HelperBinderProtocol.TX_SET_APP_HIDDEN) {
             it.writeString(packageName); it.writeInt(if (hidden) 1 else 0)
         }
+
+    // AutoContainer cluster projection: only `info` is sent over the wire; type=1000 and str=""
+    // are fixed daemon-side, and the daemon rejects any info outside {16, 18, 0}.
+    override suspend fun enableClusterFullscreen(): Boolean =
+        statusOk(HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO) { it.writeInt(16) }
+
+    override suspend fun stopClusterProjection(): Boolean =
+        statusOk(HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO) { it.writeInt(18) }
+
+    override suspend fun refreshNativeClusterStream(): Boolean =
+        statusOk(HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO) { it.writeInt(0) }
 
     /** (status,value) reply; true iff status == 0. Shared by the boolean projection ops. */
     private suspend fun statusOk(code: Int, writeArgs: (Parcel) -> Unit): Boolean =

--- a/app/src/main/kotlin/com/bydmate/app/helper/HelperBinderProtocol.kt
+++ b/app/src/main/kotlin/com/bydmate/app/helper/HelperBinderProtocol.kt
@@ -33,6 +33,8 @@ import android.os.IBinder
  *       -> reply: writeInt(status), writeInt(0)   // status 0 = settings put global succeeded; -1 = not whitelisted / failed
  *   TX_SET_APP_HIDDEN : writeString(packageName), writeInt(hidden: 1=disable 0=enable)
  *       -> reply: writeInt(status), writeInt(0)   // status 0 = ok; -1 = not whitelisted / failed
+ *   TX_AUTO_CONTAINER_SEND_INFO : writeInt(info)  // ONLY info; type=1000 and str="" are fixed in the daemon
+ *       -> reply: writeInt(status), writeInt(0)   // status 0 = sendInfo accepted; -1 = not in whitelist {16,18,0} / failed
  *
  * Projection status: 0 = success, <0 = error/unavailable. Surface is written LAST so a
  * marshalling test can assert the scalar args without round-tripping the Surface.
@@ -62,6 +64,9 @@ object HelperBinderProtocol {
     const val TX_ENABLE_ACCESSIBILITY = IBinder.FIRST_CALL_TRANSACTION + 15     // 16
     const val TX_PUT_GLOBAL_SETTING = IBinder.FIRST_CALL_TRANSACTION + 16       // 17
     const val TX_SET_APP_HIDDEN = IBinder.FIRST_CALL_TRANSACTION + 17           // 18
+    // AutoContainer.sendInfo(1000, info, "") for DiLink 5 cluster projection. Only info is sent over
+    // the wire; type=1000 and str="" are fixed daemon-side. Whitelisted to info in {16, 18, 0}.
+    const val TX_AUTO_CONTAINER_SEND_INFO = IBinder.FIRST_CALL_TRANSACTION + 18 // 19
 
     /** Our own package — target of the narrow grantOverlayPermission appops call. */
     const val APP_PACKAGE = "com.bydmate.app"

--- a/app/src/main/kotlin/com/bydmate/app/helper/HelperDaemon.kt
+++ b/app/src/main/kotlin/com/bydmate/app/helper/HelperDaemon.kt
@@ -281,6 +281,18 @@ fun main(args: Array<String>) {
                     true
                 }.getOrElse { reply?.writeInt(-1); reply?.writeInt(0); true }
 
+                HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO -> runCatching {
+                    val info = data.readInt()
+                    // Whitelist enforced by isAllowedAutoContainerInfo — ONLY 16/18/0. type=1000 and
+                    // str="" are fixed here, NOT taken from the caller: this is the privilege
+                    // boundary, not a generic passthrough.
+                    val ok = if (isAllowedAutoContainerInfo(info)) {
+                        autoContainerSendInfo(type = 1000, info = info, str = "")
+                    } else false
+                    reply?.writeInt(if (ok) 0 else -1); reply?.writeInt(0)
+                    true
+                }.getOrElse { reply?.writeInt(-1); reply?.writeInt(0); true }
+
                 else -> super.onTransact(code, data, reply, flags)
             }
         }
@@ -343,6 +355,66 @@ private fun autoserviceTransact(
     } finally {
         data2.recycle()
         reply2.recycle()
+    }
+}
+
+// The AutoContainer service is registered under different names per platform:
+//   DiLink 5.0 (BYD-AUTO, API 32) → "auto_container" (snake_case)
+//   DiLink 3.0 (Seal EU / Atto 3) → "AutoContainer"  (PascalCase)
+// Try DL5 first (our primary target), then DL3, so the daemon works on both without needing
+// platform detection here. Confirmed against byd-dashcast AdbLocalClient.autoContainerSvcName.
+// Internal so a unit test can guard the DL5-first ordering (the original bug was the wrong name).
+internal val AUTO_CONTAINER_SERVICE_NAMES = arrayOf("auto_container", "AutoContainer")
+
+/**
+ * Whitelist for AutoContainer sendInfo values. ONLY 16 (enable fullscreen projection), 18 (stop),
+ * and 0 (refresh the native cluster stream) are permitted. Value 1 disconnects Qt entirely and
+ * destroys cluster display 1 — it MUST stay rejected. Extracted as internal so the privilege
+ * boundary is unit-tested (see HelperDaemonAutoContainerTest).
+ */
+internal fun isAllowedAutoContainerInfo(info: Int): Boolean =
+    info == 16 || info == 18 || info == 0
+
+/**
+ * Sends AutoContainer.sendInfo(type, info, str) via in-process binder.transact(#2).
+ * The interface descriptor is read at runtime (INTERFACE_TRANSACTION) so an OEM rebrand still works.
+ * We do NOT shell out `service call`. Mirrors byd-dashcast Phase4ProcessVerbs.autoContainerSendInfo.
+ *
+ * The Java whitelist AutoContainerManager enforces (/system/etc/container_comm_cfg.json, only
+ * com.xdja.clusterdemo) is bypassed by the direct binder call under shell uid — which is why this
+ * only works from the daemon, not from the app process.
+ */
+private fun autoContainerSendInfo(type: Int, info: Int, str: String): Boolean {
+    val sm = Class.forName("android.os.ServiceManager")
+    val getService = sm.getMethod("getService", String::class.java)
+    val binder = AUTO_CONTAINER_SERVICE_NAMES
+        .firstNotNullOfOrNull { name ->
+            (getService.invoke(null, name) as? IBinder)?.takeIf { it.isBinderAlive }
+        } ?: return false
+
+    // Read the descriptor at runtime (INTERFACE_TRANSACTION) rather than hardcoding
+    // android.os.IAutoContainer.
+    val descriptor = run {
+        val d = Parcel.obtain(); val r = Parcel.obtain()
+        try {
+            binder.transact(IBinder.INTERFACE_TRANSACTION, d, r, 0)
+            r.readString()
+        } catch (e: Exception) { null } finally { r.recycle(); d.recycle() }
+    }?.takeIf { it.isNotEmpty() } ?: return false
+
+    val data = Parcel.obtain(); val reply = Parcel.obtain()
+    return try {
+        data.writeInterfaceToken(descriptor)
+        data.writeInt(type)
+        data.writeInt(info)
+        data.writeString(str)
+        binder.transact(2 /* sendInfo */, data, reply, 0)
+        reply.readException()   // throws on a remote-side exception → caller's getOrElse writes -1
+        true
+    } catch (e: Exception) {
+        false
+    } finally {
+        reply.recycle(); data.recycle()
     }
 }
 

--- a/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/bydmate/app/ui/settings/SettingsScreen.kt
@@ -971,6 +971,12 @@ private fun DisplaySection() {
     var triggerKey by remember {
         mutableStateOf(prefs.getInt(ClusterProjectionManager.KEY_TRIGGER_KEYCODE, DEFAULT_TRIGGER_KEYCODE))
     }
+    var autoFullscreen by remember {
+        mutableStateOf(prefs.getBoolean(ClusterProjectionManager.KEY_AUTO_ENABLE_FULLSCREEN, false))
+    }
+    var restoreNative by remember {
+        mutableStateOf(prefs.getBoolean(ClusterProjectionManager.KEY_RESTORE_NATIVE_ON_STOP, false))
+    }
 
     SectionHeader(text = stringResource(R.string.settings_display_mirror_header))
     Card(
@@ -1042,6 +1048,78 @@ private fun DisplaySection() {
                     Text(steeringButtonLabel(triggerKey), color = TextSecondary, fontSize = 12.sp, maxLines = 1)
                 }
                 Text(stringResource(R.string.settings_display_button_change), color = AccentGreen, fontSize = 13.sp)
+            }
+        }
+    }
+
+    // DiLink 5 auto full-screen projection + native-cluster restore. Only meaningful while the
+    // feature is on, so both toggles are gated on the master switch.
+    if (enabled) {
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(containerColor = CardSurfaceElevated),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.DirectionsCar,
+                    contentDescription = null,
+                    tint = AccentGreen,
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.settings_display_auto_fullscreen_title), color = TextPrimary, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                    Text(stringResource(R.string.settings_display_auto_fullscreen_desc), color = TextSecondary, fontSize = 12.sp)
+                }
+                Switch(
+                    checked = autoFullscreen,
+                    onCheckedChange = {
+                        autoFullscreen = it
+                        prefs.edit().putBoolean(ClusterProjectionManager.KEY_AUTO_ENABLE_FULLSCREEN, it).apply()
+                    },
+                    colors = bydSwitchColors(),
+                )
+            }
+        }
+
+        Card(
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(containerColor = CardSurfaceElevated),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Settings,
+                    contentDescription = null,
+                    tint = AccentGreen,
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(stringResource(R.string.settings_display_restore_native_title), color = TextPrimary, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                    Text(stringResource(R.string.settings_display_restore_native_desc), color = TextSecondary, fontSize = 12.sp)
+                }
+                Switch(
+                    checked = restoreNative,
+                    onCheckedChange = {
+                        restoreNative = it
+                        prefs.edit().putBoolean(ClusterProjectionManager.KEY_RESTORE_NATIVE_ON_STOP, it).apply()
+                    },
+                    colors = bydSwitchColors(),
+                )
             }
         }
     }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -38,6 +38,11 @@
     <!-- Cluster trigger-button picker + learn dialog -->
     <string name="settings_display_button_title">Trigger button</string>
     <string name="settings_display_button_change">Change</string>
+    <!-- DiLink 5 auto full-screen projection toggles -->
+    <string name="settings_display_auto_fullscreen_title">Auto-enable Full Screen Projection (DiLink 5)</string>
+    <string name="settings_display_auto_fullscreen_desc">BYDMate enables cluster full-screen projection before launching the app</string>
+    <string name="settings_display_restore_native_title">Restore native cluster</string>
+    <string name="settings_display_restore_native_desc">Bring the native instrument cluster back when projection stops</string>
     <string name="learn_button_dialog_title">Assign button</string>
     <string name="learn_button_waiting">Press a steering-wheel button…</string>
     <string name="learn_button_rejected">This button can\'t be assigned. Press another.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -38,6 +38,11 @@
     <!-- Cluster trigger-button picker + learn dialog -->
     <string name="settings_display_button_title">Botão de acionamento</string>
     <string name="settings_display_button_change">Alterar</string>
+    <!-- DiLink 5 auto full-screen projection toggles -->
+    <string name="settings_display_auto_fullscreen_title">Ativar Full Screen Projection automaticamente (DiLink 5)</string>
+    <string name="settings_display_auto_fullscreen_desc">O BYDMate ativa a projeção em tela cheia do painel antes de abrir o app</string>
+    <string name="settings_display_restore_native_title">Restaurar painel nativo</string>
+    <string name="settings_display_restore_native_desc">Retorna a imagem original do painel quando a projeção é interrompida</string>
     <string name="learn_button_dialog_title">Atribuir botão</string>
     <string name="learn_button_waiting">Pressione um botão do volante…</string>
     <string name="learn_button_rejected">Este botão não pode ser atribuído. Pressione outro.</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -709,8 +709,12 @@
     <string name="settings_config_restore_confirm_cancel">取消</string>
     <string name="settings_config_restore_confirm_ok">恢复</string>
     <string name="settings_config_restore_confirm_title">恢复配置？</string>
+    <string name="settings_display_auto_fullscreen_desc">投射应用前，BYDMate 会自动开启仪表盘全屏投屏</string>
+    <string name="settings_display_auto_fullscreen_title">自动开启全屏投屏（DiLink 5）</string>
     <string name="settings_display_button_change">更改</string>
     <string name="settings_display_button_title">触发按键</string>
+    <string name="settings_display_restore_native_desc">停止投射时恢复原始仪表盘画面</string>
+    <string name="settings_display_restore_native_title">恢复原始仪表盘</string>
     <string name="steering_button_aux_left">左侧辅助键</string>
     <string name="steering_button_aux_right">右侧辅助键</string>
     <string name="steering_button_carousel">仪表轮播</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,11 @@
     <!-- Cluster trigger-button picker + learn dialog -->
     <string name="settings_display_button_title">Кнопка запуска</string>
     <string name="settings_display_button_change">Изменить</string>
+    <!-- DiLink 5 auto full-screen projection toggles -->
+    <string name="settings_display_auto_fullscreen_title">Автовключение Full Screen Projection (DiLink 5)</string>
+    <string name="settings_display_auto_fullscreen_desc">Перед выводом приложения BYDMate сам включит полноэкранную проекцию приборки</string>
+    <string name="settings_display_restore_native_title">Восстанавливать штатную приборку</string>
+    <string name="settings_display_restore_native_desc">При остановке проекции вернуть штатное изображение приборной панели</string>
     <string name="learn_button_dialog_title">Назначить кнопку</string>
     <string name="learn_button_waiting">Нажмите кнопку на руле…</string>
     <string name="learn_button_rejected">Эту кнопку нельзя назначить. Нажмите другую.</string>

--- a/app/src/test/kotlin/com/bydmate/app/data/vehicle/HelperClientAutoContainerTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/data/vehicle/HelperClientAutoContainerTest.kt
@@ -1,0 +1,78 @@
+package com.bydmate.app.data.vehicle
+
+import android.os.IBinder
+import android.os.IInterface
+import android.os.Parcel
+import com.bydmate.app.helper.HelperBinderProtocol
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [29])
+class HelperClientAutoContainerTest {
+
+    private abstract class FakeIBinder : IBinder {
+        override fun isBinderAlive(): Boolean = true
+        override fun pingBinder(): Boolean = true
+        override fun getInterfaceDescriptor(): String = HelperBinderProtocol.DESCRIPTOR
+        override fun queryLocalInterface(descriptor: String): IInterface? = null
+        @Suppress("OVERRIDE_DEPRECATION")
+        override fun dump(fd: java.io.FileDescriptor, args: Array<String>?) {}
+        override fun dumpAsync(fd: java.io.FileDescriptor, args: Array<String>?) {}
+        override fun linkToDeath(recipient: IBinder.DeathRecipient, flags: Int) {}
+        override fun unlinkToDeath(recipient: IBinder.DeathRecipient, flags: Int): Boolean = true
+    }
+
+    /** Records the transaction code + the single `info` int, replies with [status]. */
+    private class RecordingBinder(private val status: Int) : FakeIBinder() {
+        var seenCode = -1
+        var seenInfo = Int.MIN_VALUE
+        override fun transact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+            seenCode = code
+            data.setDataPosition(0)
+            data.enforceInterface(HelperBinderProtocol.DESCRIPTOR)
+            seenInfo = data.readInt()
+            reply!!.writeInt(status); reply.writeInt(0)
+            reply.setDataPosition(0)
+            return true
+        }
+    }
+
+    private fun clientWith(binder: IBinder) =
+        object : HelperClientImpl() { override fun resolveBinder(): IBinder = binder }
+
+    @Test fun `enableClusterFullscreen sends info 16 and returns true on status 0`() = runBlocking {
+        val fake = RecordingBinder(status = 0)
+        val ok = clientWith(fake).enableClusterFullscreen()
+        assertTrue(ok)
+        assertEquals(HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO, fake.seenCode)
+        assertEquals(16, fake.seenInfo)
+    }
+
+    @Test fun `stopClusterProjection sends info 18`() = runBlocking {
+        val fake = RecordingBinder(status = 0)
+        val ok = clientWith(fake).stopClusterProjection()
+        assertTrue(ok)
+        assertEquals(HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO, fake.seenCode)
+        assertEquals(18, fake.seenInfo)
+    }
+
+    @Test fun `refreshNativeClusterStream sends info 0`() = runBlocking {
+        val fake = RecordingBinder(status = 0)
+        val ok = clientWith(fake).refreshNativeClusterStream()
+        assertTrue(ok)
+        assertEquals(HelperBinderProtocol.TX_AUTO_CONTAINER_SEND_INFO, fake.seenCode)
+        assertEquals(0, fake.seenInfo)
+    }
+
+    @Test fun `returns false when daemon replies error status`() = runBlocking {
+        val fake = RecordingBinder(status = -1)
+        assertFalse(clientWith(fake).enableClusterFullscreen())
+    }
+}

--- a/app/src/test/kotlin/com/bydmate/app/helper/HelperDaemonAutoContainerTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/helper/HelperDaemonAutoContainerTest.kt
@@ -1,0 +1,46 @@
+package com.bydmate.app.helper
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure JVM tests for the AutoContainer privilege boundary in HelperDaemon.
+ *
+ * These guard the two facts that made cluster projection work (and kept it safe) on DiLink 5:
+ *   1. only sendInfo values {16, 18, 0} are accepted — and 1 (which destroys the cluster display)
+ *      is rejected;
+ *   2. the service name is resolved DL5-first ("auto_container" before "AutoContainer") — the
+ *      original bug was resolving the DL3 PascalCase name only.
+ */
+class HelperDaemonAutoContainerTest {
+
+    @Test fun `whitelist accepts the three projection commands`() {
+        assertTrue("16 = enable fullscreen projection", isAllowedAutoContainerInfo(16))
+        assertTrue("18 = stop projection", isAllowedAutoContainerInfo(18))
+        assertTrue("0 = refresh native cluster stream", isAllowedAutoContainerInfo(0))
+    }
+
+    @Test fun `whitelist rejects the destructive value 1`() {
+        // sendInfo(1) disconnects Qt entirely and destroys cluster display 1 — must never pass.
+        assertFalse("1 must stay rejected", isAllowedAutoContainerInfo(1))
+    }
+
+    @Test fun `whitelist rejects DL3-only and out-of-range values`() {
+        // 30/35 are DiLink 3.0 screen-size / Di4.0 commands, never used on DL5.
+        for (v in intArrayOf(30, 35, -1, 2, 17, 19, 100, Int.MIN_VALUE, Int.MAX_VALUE)) {
+            assertFalse("value $v must be rejected", isAllowedAutoContainerInfo(v))
+        }
+    }
+
+    @Test fun `service names try DiLink 5 snake_case before DiLink 3 PascalCase`() {
+        assertArrayEquals(
+            "DL5 auto_container must be tried first, then DL3 AutoContainer",
+            arrayOf("auto_container", "AutoContainer"),
+            AUTO_CONTAINER_SERVICE_NAMES,
+        )
+        assertEquals("auto_container", AUTO_CONTAINER_SERVICE_NAMES.first())
+    }
+}


### PR DESCRIPTION
Add narrow, whitelisted daemon op (TX_AUTO_CONTAINER_SEND_INFO, sendInfo 16/18/0 only) so BYDMate enables the system cluster projection itself before launching the target app — no more manual pre-toggle via another app.

- enable fullscreen (16) in project() before display lookup; retry the XDJAScreenProjection lookup for ~3s while it appears asynchronously
- optional restore-native-cluster (18->0) on stop, behind a settings toggle
- two DisplaySection switches (auto-enable / restore) + strings (ru/en/zh/pt)
- resolve the service as auto_container on DiLink 5 (API 32), falling back to AutoContainer on DiLink 3 — snake_case is what actually registers on DL5

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/41ba99d5-6304-4565-b8af-677cae605ad1" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6f99dd73-834e-42cb-8fe8-afbdf6cf437c" />

