### PR TITLE
Close projection-launched app on exit

### DIFF
--- a/app/src/main/kotlin/com/bydmate/app/cluster/ClusterProjectionManager.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/ClusterProjectionManager.kt
@@ -109,6 +109,8 @@ object ClusterProjectionManager {
     // back, not the live settings target — the two differ when the user switches the projection app
     // mid-projection, and tugging the new target would strand the old app on the cluster.
     private var projectedPackage: String? = null
+    // Existing tasks return to display 0; a task launched only for projection is removed on exit.
+    private var projectedTaskOrigin: ProjectionTaskOrigin? = null
     // PROJECT_MEDIA has no app-side query API (unlike SYSTEM_ALERT_WINDOW / canDrawOverlays),
     // so we grant both via the daemon once per process the first time we project.
     private var projectionPermissionsGranted = false
@@ -320,9 +322,10 @@ object ClusterProjectionManager {
     ) {
         when (mode) {
             ClusterMode.OFF -> {
-                pullBackToMain(context, helper, focus = true)
+                exitProjection(context, helper)
                 hideOverlay(helper)
                 projectedPackage = null
+                projectedTaskOrigin = null
                 currentMode = ClusterMode.OFF
                 lastFailure = null
                 if (autoContainerEnabled(context)) powerDownCompositor(context, helper)
@@ -338,6 +341,7 @@ object ClusterProjectionManager {
                     Log.e(TAG, "projection failed; falling back to OFF")
                     pullBackToMain(context, helper, focus = true)
                     projectedPackage = null
+                    projectedTaskOrigin = null
                     currentMode = ClusterMode.OFF
                     lastFailure = failure
                     if (autoContainerEnabled(context)) powerDownCompositor(context, helper)
@@ -452,12 +456,20 @@ object ClusterProjectionManager {
             remoteDisplayId = id
             saveLastVdId(context, id)
             val pkg = targetPackage(context)
+            // Capture the task's origin before launchAndForce potentially creates it. Preserve the
+            // original value during a live resize/rebuild so a BYDMate-launched task still closes.
+            val origin = projectedTaskOrigin ?: if (helper.getTaskId(pkg) != null) {
+                ProjectionTaskOrigin.ALREADY_RUNNING
+            } else {
+                ProjectionTaskOrigin.LAUNCHED_FOR_PROJECTION
+            }
             Log.i(TAG, "VirtualDisplay id=$id ${plan.bufferWidth}x${plan.bufferHeight}@${plan.densityDpi}; launchAndForce $pkg")
             val ok = helper.launchAndForce(pkg, id, plan.bufferWidth, plan.bufferHeight)
             if (!ok) {
                 Log.e(TAG, "launchAndForce failed"); hideOverlay(helper); return "projection"
             }
             projectedPackage = pkg
+            projectedTaskOrigin = origin
             null
         } catch (e: Exception) {
             // wm.addView (BadTokenException) or any reflective daemon call can throw — tear the
@@ -562,6 +574,29 @@ object ClusterProjectionManager {
         helper.moveTaskToDisplay(taskId, 0)
         helper.setTaskBounds(taskId, 0, 0, 0, 0)
         if (focus) helper.setFocusedTask(taskId)
+    }
+
+    /** Restore a pre-existing task, or remove a task launched solely for this projection session. */
+    private suspend fun exitProjection(context: Context, helper: HelperClient) {
+        if (!shouldCloseOnProjectionExit(projectedTaskOrigin)) {
+            pullBackToMain(context, helper, focus = true)
+            return
+        }
+
+        val pkg = projectedPackage ?: targetPackage(context)
+        val taskId = helper.getTaskId(pkg)
+        if (taskId == null) {
+            Log.d(TAG, "exitProjection: launched task ($pkg) already gone")
+            return
+        }
+        if (helper.removeTask(taskId)) {
+            Log.i(TAG, "exitProjection: removed task $taskId ($pkg) launched for projection")
+        } else {
+            // Never release a display with a live task stranded on it. Restore it when this DiLink
+            // build lacks or blocks ActivityTaskManager.removeTask().
+            Log.w(TAG, "exitProjection: removeTask($taskId) failed; restoring to main display")
+            pullBackToMain(context, helper, focus = true)
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/bydmate/app/cluster/ClusterProjectionState.kt
+++ b/app/src/main/kotlin/com/bydmate/app/cluster/ClusterProjectionState.kt
@@ -6,6 +6,13 @@ const val NAVI_PACKAGE = "ru.yandex.yandexnavi"
 /** Cluster projection state (OFF / FULLSCREEN). */
 enum class ClusterMode { OFF, FULLSCREEN }
 
+/** How the target task entered a projection session. */
+enum class ProjectionTaskOrigin { ALREADY_RUNNING, LAUNCHED_FOR_PROJECTION }
+
+/** A task launched solely for projection is closed on exit; an existing task is restored. */
+fun shouldCloseOnProjectionExit(origin: ProjectionTaskOrigin?): Boolean =
+    origin == ProjectionTaskOrigin.LAUNCHED_FOR_PROJECTION
+
 /** Where Navi renders on the cluster overlay. VirtualDisplay size == SurfaceView size (1:1). */
 data class ClusterGeometry(val width: Int, val height: Int, val xOffset: Int, val yOffset: Int)
 

--- a/app/src/main/kotlin/com/bydmate/app/data/vehicle/HelperClient.kt
+++ b/app/src/main/kotlin/com/bydmate/app/data/vehicle/HelperClient.kt
@@ -54,6 +54,8 @@ interface HelperClient {
     /** Task id of [packageName]'s running task, or null if not running / channel unavailable. */
     suspend fun getTaskId(packageName: String): Int?
     suspend fun moveTaskToDisplay(taskId: Int, displayId: Int): Boolean
+    /** Removes exactly [taskId] from recents/running tasks; does not force-stop the package. */
+    suspend fun removeTask(taskId: Int): Boolean
     suspend fun setTaskBounds(taskId: Int, left: Int, top: Int, right: Int, bottom: Int): Boolean
     suspend fun setFocusedTask(taskId: Int): Boolean
     suspend fun setTaskWindowingMode(taskId: Int, windowingMode: Int): Boolean
@@ -160,6 +162,9 @@ open class HelperClientImpl @Inject constructor() : HelperClient {
 
     override suspend fun moveTaskToDisplay(taskId: Int, displayId: Int): Boolean =
         statusOk(HelperBinderProtocol.TX_MOVE_TASK_TO_DISPLAY) { it.writeInt(taskId); it.writeInt(displayId) }
+
+    override suspend fun removeTask(taskId: Int): Boolean =
+        statusOk(HelperBinderProtocol.TX_REMOVE_TASK) { it.writeInt(taskId) }
 
     override suspend fun setTaskBounds(taskId: Int, left: Int, top: Int, right: Int, bottom: Int): Boolean =
         statusOk(HelperBinderProtocol.TX_SET_TASK_BOUNDS) {

--- a/app/src/main/kotlin/com/bydmate/app/helper/HelperBinderProtocol.kt
+++ b/app/src/main/kotlin/com/bydmate/app/helper/HelperBinderProtocol.kt
@@ -35,6 +35,7 @@ import android.os.IBinder
  *       -> reply: writeInt(status), writeInt(0)   // status 0 = ok; -1 = not whitelisted / failed
  *   TX_ENABLE_NOTIFICATION_LISTENER : (no args)           -> reply: writeInt(status), writeInt(0)  // status 0 = our listener stub enabled
  *   TX_SET_CLUSTER_MODE: [int on(0|1)] -> [int status]; status 0 = ok.
+ *   TX_REMOVE_TASK: writeInt(taskId)                         -> reply: writeInt(status), writeInt(0)
  *
  * Projection status: 0 = success, <0 = error/unavailable. Surface is written LAST so a
  * marshalling test can assert the scalar args without round-tripping the Surface.
@@ -78,6 +79,9 @@ object HelperBinderProtocol {
      * "batch unsupported" and falls back to per-fid reads.
      */
     val TX_READ_BATCH: Int = IBinder.FIRST_CALL_TRANSACTION + 20
+
+    /** Removes one specific recent/root task. Used to close an app BYDMate launched for projection. */
+    val TX_REMOVE_TASK: Int = IBinder.FIRST_CALL_TRANSACTION + 21
 
     /** Hard cap on items per TX_READ_BATCH call (FidMap is 58 today; 128 leaves headroom). */
     const val MAX_BATCH_ITEMS: Int = 128

--- a/app/src/main/kotlin/com/bydmate/app/helper/HelperDaemon.kt
+++ b/app/src/main/kotlin/com/bydmate/app/helper/HelperDaemon.kt
@@ -169,6 +169,12 @@ fun main(args: Array<String>) {
                     true
                 }.getOrElse { reply?.writeInt(-1); reply?.writeInt(0); true }
 
+                HelperBinderProtocol.TX_REMOVE_TASK -> runCatching {
+                    val removed = removeTaskReflect(data.readInt())
+                    reply?.writeInt(if (removed) 0 else -1); reply?.writeInt(0)
+                    true
+                }.getOrElse { reply?.writeInt(-1); reply?.writeInt(0); true }
+
                 HelperBinderProtocol.TX_SET_TASK_BOUNDS -> runCatching {
                     val taskId = data.readInt()
                     val l = data.readInt(); val t = data.readInt(); val r = data.readInt(); val b = data.readInt()
@@ -457,6 +463,17 @@ private fun moveTaskToDisplayReflect(taskId: Int, displayId: Int) {
         ?: iAtm.javaClass.methods.firstOrNull { it.name == "moveTaskToDisplay" && it.parameterTypes.size == 2 }
         ?: throw NoSuchMethodException("moveTaskToDisplay")
     m.invoke(iAtm, taskId, displayId)
+}
+
+/** Remove one task without force-stopping its package or accepting a shell command. */
+private fun removeTaskReflect(taskId: Int): Boolean {
+    if (taskId <= 0) return false
+    val iAtm = activityTaskManager()
+    val method = iAtm.javaClass.methods.firstOrNull {
+        it.name == "removeTask" && it.parameterTypes.size == 1 &&
+            it.parameterTypes[0] == Int::class.javaPrimitiveType
+    } ?: throw NoSuchMethodException("removeTask")
+    return (method.invoke(iAtm, taskId) as? Boolean) ?: true
 }
 
 private fun setTaskWindowingModeReflect(taskId: Int, windowingMode: Int) {

--- a/app/src/test/kotlin/com/bydmate/app/cluster/ClusterProjectionStateTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/cluster/ClusterProjectionStateTest.kt
@@ -1,10 +1,24 @@
 package com.bydmate.app.cluster
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ClusterProjectionStateTest {
+
+    @Test fun `existing task is restored when projection exits`() {
+        assertFalse(shouldCloseOnProjectionExit(ProjectionTaskOrigin.ALREADY_RUNNING))
+    }
+
+    @Test fun `task launched for projection is closed when projection exits`() {
+        assertTrue(shouldCloseOnProjectionExit(ProjectionTaskOrigin.LAUNCHED_FOR_PROJECTION))
+    }
+
+    @Test fun `unknown origin defaults to restore not close`() {
+        assertFalse(shouldCloseOnProjectionExit(null))
+    }
 
     @Test fun `fullscreen geometry fills the whole cluster`() {
         assertEquals(

--- a/app/src/test/kotlin/com/bydmate/app/data/vehicle/HelperClientProjectionTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/data/vehicle/HelperClientProjectionTest.kt
@@ -93,6 +93,15 @@ class HelperClientProjectionTest {
     }
 
     @Test
+    fun `removeTask sends only taskId and maps status`() = runBlocking {
+        var taskId = 0
+        assertTrue(clientWith(capturingFake(status = 0, value = 0) { taskId = it.readInt() })
+            .removeTask(57))
+        assertEquals(57, taskId)
+        assertFalse(clientWith(capturingFake(status = -1, value = 0)).removeTask(57))
+    }
+
+    @Test
     fun `setTaskBounds sends taskId then four edges in order`() = runBlocking {
         val got = IntArray(5)
         val ok = clientWith(capturingFake(status = 0, value = 0) {


### PR DESCRIPTION
## What changed

- remember whether the projected app task was already running or was launched by BYDMate
- restore pre-existing tasks to the tablet on the second steering-wheel press
- remove tasks launched solely for cluster projection on the second press
- add a narrow helper Binder transaction for removing one task by ID
- fall back to restoring the task to the tablet when task removal is unsupported or fails

## Why

`launchAndForce()` automatically launches a missing projection target, but the projection manager previously retained only the package name. On exit it therefore always moved the task to display 0, even when BYDMate had launched the app solely for projection.

The manager now records the task origin before projection and applies the matching exit behavior without force-stopping the package.

## User impact

- App already open: tablet → cluster → tablet
- App initially closed: launch on cluster → close task

## Validation

- `./gradlew :app:testDebugUnitTest :app:lintDebug --stacktrace`
- focused projection state and Binder marshalling regression tests
- `git diff --check`

Physical validation on a DiLink 5.0 head unit is still recommended because `ActivityTaskManager.removeTask()` is a private/vendor-dependent path. The implementation safely restores the task to the tablet if removal is unavailable.
