### PR TITLE
fix: 2GIS silently dies when its live task is moved to the cluster display

### DIFF
--- a/app/src/main/kotlin/com/bydmate/app/helper/HelperDaemon.kt
+++ b/app/src/main/kotlin/com/bydmate/app/helper/HelperDaemon.kt
@@ -1300,7 +1300,12 @@ internal fun launchAppCore(
     if (!packageName.matches(Regex("[A-Za-z0-9_.]+"))) return false
     // STANDARD is what `am start` assigns by default — only RECENTS needs the explicit flag.
     val typeFlag = if (activityType == ACTIVITY_TYPE_RECENTS) "--activityType $ACTIVITY_TYPE_RECENTS " else ""
-    val modePrefix = if (windowingMode != null) "--windowingMode $windowingMode $typeFlag--display $displayId " else ""
+    // displayId != 0 births the task on the target display: 2GIS/Qt dies on a cross-display move.
+    val modePrefix = when {
+        windowingMode != null -> "--windowingMode $windowingMode $typeFlag--display $displayId "
+        displayId != 0 -> "--display $displayId "
+        else -> ""
+    }
     val component = resolveComponent(packageName)
     if (component != null) {
         // Component is passed as positional "$1" — never interpolated into the sh -c string.
@@ -1551,7 +1556,10 @@ private fun resolveOrLaunchTask(
  * Blocking (Thread.sleep) — runs on a binder threadpool thread; the app side uses a 15s timeout.
  */
 private fun launchAndForce(packageName: String, displayId: Int, width: Int, height: Int): Boolean {
-    val taskId = resolveOrLaunchTask(packageName, activityType = ACTIVITY_TYPE_STANDARD) // ignored: windowingMode == null
+    // Not-yet-running apps are born on the target display — 2GIS/Qt dies if moved there instead.
+    val taskId = resolveOrLaunchTask(
+        packageName, windowingMode = null, displayId = displayId, activityType = ACTIVITY_TYPE_STANDARD,
+    )
     if (taskId <= 0) return false
     // Each redirect op is best-effort, mirroring CarControlImpl (every reflective call there returns
     // a status string and swallows its own exception). resizeTask in particular throws "not allowed"
@@ -1564,6 +1572,15 @@ private fun launchAndForce(packageName: String, displayId: Int, width: Int, heig
         runCatching { setTaskBoundsReflect(taskId, 0, 0, width, height) }
         runCatching { setFocusedTaskReflect(taskId) }
         Thread.sleep(200L)
+    }
+    // App died during the move (2GIS/Qt) → relaunch ONCE born on the display; no retry loop.
+    if (findTaskId(packageName) <= 0) {
+        val rebornId = resolveOrLaunchTask(
+            packageName, windowingMode = null, displayId = displayId, activityType = ACTIVITY_TYPE_STANDARD,
+        )
+        if (rebornId <= 0) return false
+        runCatching { setTaskBoundsReflect(rebornId, 0, 0, width, height) }
+        runCatching { setFocusedTaskReflect(rebornId) }
     }
     return true
 }

--- a/app/src/test/kotlin/com/bydmate/app/helper/LaunchAppCoreTest.kt
+++ b/app/src/test/kotlin/com/bydmate/app/helper/LaunchAppCoreTest.kt
@@ -107,6 +107,25 @@ class LaunchAppCoreTest {
         assertTrue("first command must be plain am start -n", shellCmds.first().startsWith("am start -n "))
     }
 
+    @Test
+    fun `plain path with target display births the task there via display-only flag`() {
+        val commands = mutableListOf<String>()
+        launchAppCore("ru.dublgis.dgismobile", null, 7, ACTIVITY_TYPE_STANDARD,
+            resolveComponent = { "ru.dublgis.dgismobile/.GrymMobileActivity" },
+            shell = { cmd, _ -> commands += cmd; "" })
+        assertEquals("am start --display 7 -n \"\$1\"", commands[0])
+        assertTrue("must not carry --windowingMode", commands.none { "--windowingMode" in it })
+    }
+
+    @Test
+    fun `plain path on main display keeps the legacy flagless command`() {
+        val commands = mutableListOf<String>()
+        launchAppCore("ru.dublgis.dgismobile", null, 0, ACTIVITY_TYPE_STANDARD,
+            resolveComponent = { "ru.dublgis.dgismobile/.GrymMobileActivity" },
+            shell = { cmd, _ -> commands += cmd; "" })
+        assertEquals("am start -n \"\$1\"", commands[0])
+    }
+
     // --- validation gate ---
 
     @Test


### PR DESCRIPTION
The VD projection pipeline (launchAndForce) launched the navigator on the main display and then moved the live task to the VirtualDisplay. 2GIS is built on Qt (Grym engine): its native render loop is tied to the EGL surface of the display the task was born on, and on a cross-display move the engine terminates its own process — no Java crash, just 'Process ru.dublgis.dgismobile has died' at the exact moment of the move. The task is then removed and nothing appears on the cluster. Yandex Navigator survives the same move because it handles window recreation like a normal config change.

Fix, two layers in the daemon:
- launchAppCore: with windowingMode == null and displayId != 0 the launch command is 'am start --display N …', so a not-yet-running app is BORN on the target display and the killing move never happens.
- launchAndForce: passes displayId through to resolveOrLaunchTask, and after the pin loop checks the task still exists; if the app killed itself during a move it is relaunched once born on the display.

Verified on-car 2026-08-01: 2GIS projects to the instrument cluster and stays alive; the recovery branch was observed handling died-during-move.